### PR TITLE
use travis build number to increment version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ install:
   - go mod download
 script:
   - go test ./... -v
-  - GOOS=linux GOARCH=amd64 go build -o nancy-linux.amd64-$VERSION
-  - GOOS=darwin GOARCH=amd64 go build -o nancy-darwin.amd64-$VERSION
-  - GOOS=windows GOARCH=amd64 go build -o nancy-windows.amd64-$VERSION.exe
+  - GOOS=linux GOARCH=amd64 go build -ldflags="-X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildVersion=$VERSION' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildTime=$time' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildCommit=$TRAVIS_COMMIT'" -o nancy-linux.amd64-$VERSION
+  - GOOS=darwin GOARCH=amd64 go build -ldflags="-X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildVersion=$VERSION' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildTime=$time' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildCommit=$TRAVIS_COMMIT'" -o nancy-darwin.amd64-$VERSION
+  - GOOS=windows GOARCH=amd64 go build -ldflags="-X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildVersion=$VERSION' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildTime=$time' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildCommit=$TRAVIS_COMMIT'" -o nancy-windows.amd64-$VERSION.exe
 env:
-  - GO111MODULE=on VERSION=0.0.1
+  - GO111MODULE=on VERSION=0.0.$TRAVIS_BUILD_NUMBER
 
 before_deploy:
   - export TRAVIS_TAG=$VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 language: go
 go:
   - 1.11.x
+before_install:
+  - ./bumpver.sh
 install:
   - go mod download
 script:
@@ -11,7 +13,7 @@ script:
   - GOOS=darwin GOARCH=amd64 go build -ldflags="-X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildVersion=$VERSION' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildTime=$time' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildCommit=$TRAVIS_COMMIT'" -o nancy-darwin.amd64-$VERSION
   - GOOS=windows GOARCH=amd64 go build -ldflags="-X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildVersion=$VERSION' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildTime=$time' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildCommit=$TRAVIS_COMMIT'" -o nancy-windows.amd64-$VERSION.exe
 env:
-  - GO111MODULE=on VERSION=0.0.$TRAVIS_BUILD_NUMBER
+  - GO111MODULE=on VERSION=$NEW_VERSION
 
 before_deploy:
   - export TRAVIS_TAG=$VERSION

--- a/buildversion/version.go
+++ b/buildversion/version.go
@@ -1,0 +1,8 @@
+package buildversion
+
+var (
+	// these are populated via build CLI
+	BuildVersion = ""
+	BuildTime    = ""
+	BuildCommit  = ""
+)

--- a/bumpver.sh
+++ b/bumpver.sh
@@ -1,7 +1,7 @@
 export LAST_VERSION=$(git describe --abbrev=0 --tags)
 echo $LAST_VERSION
 
-export LAST_PREFIX=$(cut -d'.' -f1 -f2 <<< $LAST_VERSION)
+export LAST_PREFIX=$(cut -d'.' -f1,2 <<< $LAST_VERSION)
 echo $LAST_PREFIX
 
 export LAST_SUFFIX=$(cut -d'.' -f3 <<< $LAST_VERSION)

--- a/bumpver.sh
+++ b/bumpver.sh
@@ -1,0 +1,15 @@
+export LAST_VERSION=$(git describe --abbrev=0 --tags)
+echo $LAST_VERSION
+
+export LAST_PREFIX=$(cut -d'.' -f1 -f2 <<< $LAST_VERSION)
+echo $LAST_PREFIX
+
+export LAST_SUFFIX=$(cut -d'.' -f3 <<< $LAST_VERSION)
+echo $LAST_SUFFIX
+
+export NEW_SUFFIX=$(expr "$LAST_SUFFIX" + 1)
+echo $NEW_SUFFIX
+
+export NEW_VERSION="$LAST_PREFIX.$NEW_SUFFIX"
+echo $NEW_VERSION
+

--- a/main.go
+++ b/main.go
@@ -17,14 +17,13 @@ import (
 	"flag"
 	"fmt"
 	"github.com/sonatype-nexus-community/nancy/audit"
+	"github.com/sonatype-nexus-community/nancy/buildversion"
 	"github.com/sonatype-nexus-community/nancy/customerrors"
 	"github.com/sonatype-nexus-community/nancy/ossindex"
 	"github.com/sonatype-nexus-community/nancy/packages"
 	"github.com/sonatype-nexus-community/nancy/parse"
 	"os"
 )
-
-const AppVersion = "0.0.1"
 
 var noColorPtr *bool
 var path string
@@ -36,7 +35,7 @@ func main() {
 	version := flag.Bool("version", false, "prints current nancy version")
 
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: nancy [options] <Gopkg.lock>\n\nOptions:\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Usage: nancy [options] <Gopkg.lock>\n\nOptions:\n")
 		flag.PrintDefaults()
 		os.Exit(2)
 	}
@@ -50,7 +49,9 @@ func main() {
 	flag.Parse()
 
 	if *version {
-		fmt.Println(AppVersion)
+		fmt.Println(buildversion.BuildVersion)
+		_, _ = fmt.Printf("build time: %s\n", buildversion.BuildTime)
+		_, _ = fmt.Printf("build commit: %s\n", buildversion.BuildCommit)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
This pull request makes the following changes:
* use travis build number to increment version in a "continuous delivery" for binary artifacts

Using ideas from here: https://blog.polyverse.io/how-to-embed-versioning-information-in-go-applications-f76e2579b572

travis env doco: https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables