### PR TITLE
Print nancy version on error and set a default version of "development".

### DIFF
--- a/buildversion/version.go
+++ b/buildversion/version.go
@@ -1,8 +1,9 @@
 package buildversion
 
+
 var (
-	// these are populated via build CLI
-	BuildVersion = ""
+	// these are overwritten/populated via build CLI
+	BuildVersion = "development"
 	BuildTime    = ""
 	BuildCommit  = ""
 )

--- a/buildversion/version.go
+++ b/buildversion/version.go
@@ -1,6 +1,5 @@
 package buildversion
 
-
 var (
 	// these are overwritten/populated via build CLI
 	BuildVersion = "development"

--- a/buildversion/version_test.go
+++ b/buildversion/version_test.go
@@ -1,0 +1,18 @@
+package buildversion
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDefaultVersion(t *testing.T) {
+	assert.Equal(t, "development", BuildVersion)
+}
+
+func TestDefaultBuildTime(t *testing.T) {
+	assert.Equal(t, "", BuildTime)
+}
+
+func TestDefaultBuildCommit(t *testing.T) {
+	assert.Equal(t, "", BuildCommit)
+}

--- a/customerrors/error.go
+++ b/customerrors/error.go
@@ -15,6 +15,7 @@ package customerrors
 
 import (
 	"fmt"
+	"github.com/sonatype-nexus-community/nancy/buildversion"
 	"os"
 )
 
@@ -35,6 +36,7 @@ func Check(err error, message string) {
 	if err != nil {
 		myErr := SwError{Message: message, Err: err}
 		fmt.Println(myErr.Error())
+		fmt.Println("nancy version:", buildversion.BuildVersion)
 		myErr.Exit()
 	}
 }


### PR DESCRIPTION

This pull request makes the following changes:
Print nancy version on error and set a default version of "development".


Inspired by #9
