### PR TITLE
Add in a user-agent header 

### DIFF
--- a/ossindex/ossindex.go
+++ b/ossindex/ossindex.go
@@ -169,10 +169,12 @@ func AuditPackages(purls []string) ([]types.Coordinate, error) {
 }
 
 func setupRequest(jsonStr []byte) (req *http.Request, err error) {
-	if req, err = http.NewRequest(
+	req, err = http.NewRequest(
 		"POST",
 		getOssIndexUrl(),
-		bytes.NewBuffer(jsonStr)); err != nil {
+		bytes.NewBuffer(jsonStr),
+	)
+	if err != nil {
 		return nil, err
 	}
 

--- a/ossindex/ossindex.go
+++ b/ossindex/ossindex.go
@@ -176,7 +176,7 @@ func setupRequest(jsonStr []byte) (req *http.Request, err error) {
 		return nil, err
 	}
 
-	req.Header.Set("User-agent", fmt.Sprintf("nancy-client/%s", buildversion.BuildVersion))
+	req.Header.Set("User-Agent", fmt.Sprintf("nancy-client/%s", buildversion.BuildVersion))
 	req.Header.Set("Content-Type", "application/json")
 
 	return req, nil

--- a/ossindex/ossindex.go
+++ b/ossindex/ossindex.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/dgraph-io/badger"
+	"github.com/sonatype-nexus-community/nancy/buildversion"
 	"github.com/sonatype-nexus-community/nancy/customerrors"
 	"github.com/sonatype-nexus-community/nancy/types"
 	"io/ioutil"
@@ -110,14 +111,10 @@ func AuditPackages(purls []string) ([]types.Coordinate, error) {
 		request.Coordinates = newPurls
 		var jsonStr, _ = json.Marshal(request)
 
-		var req *http.Request
-		if req, err = http.NewRequest(
-			"POST",
-			getOssIndexUrl(),
-			bytes.NewBuffer(jsonStr)); err != nil {
+		req, err := setupRequest(jsonStr)
+		if err != nil {
 			return nil, err
 		}
-		req.Header.Set("Content-Type", "application/json")
 
 		client := &http.Client{}
 		resp, err := client.Do(req)
@@ -169,4 +166,18 @@ func AuditPackages(purls []string) ([]types.Coordinate, error) {
 		}
 	}
 	return results, nil
+}
+
+func setupRequest(jsonStr []byte) (req *http.Request, err error) {
+	if req, err = http.NewRequest(
+		"POST",
+		getOssIndexUrl(),
+		bytes.NewBuffer(jsonStr)); err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-agent", fmt.Sprintf("nancy-client/%s", buildversion.BuildVersion))
+	req.Header.Set("Content-Type", "application/json")
+
+	return req, nil
 }

--- a/ossindex/ossindex_test.go
+++ b/ossindex/ossindex_test.go
@@ -248,3 +248,23 @@ func TestAuditPackages_SinglePackage_Cached_WithExpiredTTL(t *testing.T) {
 	assert.Equal(t, []types.Coordinate{expectedCoordinate}, coordinates)
 	assert.Nil(t, err)
 }
+
+func TestSetupRequest(t *testing.T) {
+	coordJson, _ := setupJson(t)
+	req, err := setupRequest(coordJson)
+
+	assert.Equal(t, req.Header.Get("User-agent"), "nancy-client/development")
+	assert.Equal(t, req.Header.Get("Content-Type"), "application/json")
+	assert.Equal(t, req.Method, "POST")
+	assert.Nil(t, err)
+}
+
+// TODO: Use this for more than just TestSetupRequest
+func setupJson(t *testing.T) (coordJson []byte, err error) {
+	coordJson, err = json.Marshal(expectedCoordinate)
+	if err != nil {
+		t.Errorf("Couldn't setup json")
+	}
+
+	return
+}

--- a/ossindex/ossindex_test.go
+++ b/ossindex/ossindex_test.go
@@ -253,7 +253,7 @@ func TestSetupRequest(t *testing.T) {
 	coordJson, _ := setupJson(t)
 	req, err := setupRequest(coordJson)
 
-	assert.Equal(t, req.Header.Get("User-agent"), "nancy-client/development")
+	assert.Equal(t, req.Header.Get("User-Agent"), "nancy-client/development")
 	assert.Equal(t, req.Header.Get("Content-Type"), "application/json")
 	assert.Equal(t, req.Method, "POST")
 	assert.Nil(t, err)


### PR DESCRIPTION
Add in a user-agent header on the request so that we can start seeing what version people end up using, if people are using `nancy` versus just hitting OSS Index on their own, etc...

This pull request makes the following changes:
* Add's a `User-agent` header to the request, sets it to `nancy-client/version`
* Abstracts the request code into it's own function (make the world a better place!)
