### PR TITLE
Minor license header clean up.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2018 Sonatype Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 A lot of awesome people have contributed to this project! Here they are:
 
 Sonatype internal people:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2018 Sonatype Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <p align="center">
     <img src="https://github.com/sonatype-nexus-community/nancy/blob/master/docs/images/nancy_withoutlogo.png" width="300"/>
 </p>

--- a/audit/auditlog.go
+++ b/audit/auditlog.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+
 package audit
 
 import (

--- a/audit/auditlog_test.go
+++ b/audit/auditlog_test.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+
 package audit
 
 import (

--- a/buildversion/version.go
+++ b/buildversion/version.go
@@ -1,3 +1,19 @@
+//
+// Copyright 2018 Sonatype Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package buildversion
 
 var (

--- a/buildversion/version_test.go
+++ b/buildversion/version_test.go
@@ -1,3 +1,19 @@
+//
+// Copyright 2018 Sonatype Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package buildversion
 
 import (

--- a/bumpver.sh
+++ b/bumpver.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
+#
+# Copyright 2018 Sonatype Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 export LAST_PREFIX=$(cut -d'.' -f1,2 <<< $VERSION)
 echo $LAST_PREFIX
 

--- a/customerrors/error.go
+++ b/customerrors/error.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+
 package customerrors
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+
 package main
 
 import (

--- a/ossindex/ossindex.go
+++ b/ossindex/ossindex.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 // Definitions and functions for processing the OSS Index Feed
 package ossindex

--- a/ossindex/ossindex_test.go
+++ b/ossindex/ossindex_test.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 // Definitions and functions for processing the OSS Index Feed
 package ossindex

--- a/packages/dep.go
+++ b/packages/dep.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+
 package packages
 
 import (

--- a/packages/dep_test.go
+++ b/packages/dep_test.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+
 package packages
 
 import (

--- a/packages/mod.go
+++ b/packages/mod.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+
 package packages
 
 import "strings"

--- a/packages/mod_test.go
+++ b/packages/mod_test.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+
 package packages
 
 import (

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+
 package packages
 
 import (

--- a/packages/packages_test.go
+++ b/packages/packages_test.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+
 package packages
 
 import (

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+
 package parse
 
 import (

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+
 package parse
 
 import (

--- a/types/types.go
+++ b/types/types.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2018 Sonatype Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+
 package types
 
 import (


### PR DESCRIPTION
Minor changes to clean up the license headers so that they can be checked by CI in the future.

This pull request makes the following changes:
* Adds a couple of missing license headers.
* Tweaks the header formatting for future CI checks for license headers.