### PR TITLE
Better `curl` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ $ go build
 
 Each commit to master creates a new release binary, and if you'd like to skip building from source, you can download a binary similar to:
 
-`curl https://github.com/sonatype-nexus-community/nancy/releases/download/0.0.4/nancy-linux.amd64-0.0.4 > /path/where/you/want/nancy`
+`curl -O /path/where/you/want/nancy \ 
+  https://github.com/sonatype-nexus-community/nancy/releases/download/0.0.4/nancy-linux.amd64-0.0.4`
 
 ## Development
 


### PR DESCRIPTION
quick doc fix - use `curl -O ..` rather than `curl ... > outputfile`.