### PR TITLE
Change Golang purls to only use golang/

### DIFF
--- a/audit/auditlog.go
+++ b/audit/auditlog.go
@@ -15,21 +15,21 @@ package audit
 
 import (
 	"fmt"
+	"strconv"
+
 	aurora "github.com/logrusorgru/aurora"
 	"github.com/sonatype-nexus-community/nancy/types"
-	"strconv"
-	"strings"
 )
 
 func logPackage(noColor bool, idx int, packageCount int, coordinate types.Coordinate) {
 	if noColor {
 		fmt.Println("["+strconv.Itoa(idx)+"/"+strconv.Itoa(packageCount)+"]",
-			strings.Replace(coordinate.Coordinates, "pkg:", "", 1),
-			"   No known vulnerabilities against package/version...")
+			coordinate.Coordinates,
+			"   No known vulnerabilities against package/version")
 	} else {
 		fmt.Println("["+strconv.Itoa(idx)+"/"+strconv.Itoa(packageCount)+"]",
-			aurora.Bold(strings.Replace(coordinate.Coordinates, "pkg:", "", 1)),
-			aurora.Gray("   No known vulnerabilities against package/version..."))
+			aurora.Bold(coordinate.Coordinates),
+			aurora.Gray("   No known vulnerabilities against package/version"))
 	}
 }
 
@@ -37,7 +37,7 @@ func logVulnerablePackage(noColor bool, idx int, packageCount int, coordinate ty
 	if noColor {
 		fmt.Println("------------------------------------------------------------")
 		fmt.Println("["+strconv.Itoa(idx)+"/"+strconv.Itoa(packageCount)+"]",
-			strings.Replace(coordinate.Coordinates, "pkg:", "", 1)+"  [Vulnerable]",
+			coordinate.Coordinates+"  [Vulnerable]",
 			"   "+strconv.Itoa(len(coordinate.Vulnerabilities)),
 			"known vulnerabilities affecting installed version")
 
@@ -53,7 +53,7 @@ func logVulnerablePackage(noColor bool, idx int, packageCount int, coordinate ty
 	} else {
 		fmt.Println("------------------------------------------------------------")
 		fmt.Println("["+strconv.Itoa(idx)+"/"+strconv.Itoa(packageCount)+"]",
-			aurora.Bold(aurora.Red(strings.Replace(coordinate.Coordinates, "pkg:", "", 1)+"  [Vulnerable]")),
+			aurora.Bold(aurora.Red(coordinate.Coordinates+"  [Vulnerable]")),
 			"   "+strconv.Itoa(len(coordinate.Vulnerabilities)),
 			"known vulnerabilities affecting installed version")
 

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -13,14 +13,6 @@
 // limitations under the License.
 package packages
 
-import (
-	"regexp"
-)
-
-var githubPattern = regexp.MustCompile("^github.com/([^/]+)/([^/]+).*")
-var gopkg1Pattern = regexp.MustCompile("^gopkg.in/([^.]+).*")
-var gopkg2Pattern = regexp.MustCompile("^gopkg.in/([^/]+)/([^.]+).*")
-
 // Packages is meant to be implemented for any package format such as dep, go mod, etc..
 type Packages interface {
 	ExtractPurlsFromManifest() []string
@@ -30,24 +22,7 @@ type Packages interface {
 // convertGopkgNameToPurl will convert the Gopkg name into a Package URL
 //
 // FIXME: Research the various Gopkg name formats and convert them correctly
-func convertGopkgNameToPurl(name string) string {
-	switch {
-	case githubPattern.MatchString(name):
-		// Currently OSS Index's github format support is based on repository
-		// owner/name, so restrict the PURL name path.
-		//
-		// Once golang format support is improved we can switch to that and get
-		// more precise and refined results on repository sub-paths
-		name = githubPattern.ReplaceAllString(name, "github/$1/$2")
-
-	case gopkg2Pattern.MatchString(name):
-		name = gopkg2Pattern.ReplaceAllString(name, "github/$1/$2")
-
-	case gopkg1Pattern.MatchString(name):
-		name = gopkg1Pattern.ReplaceAllString(name, "github/go-$1/$1")
-
-	default:
-		name = "golang/" + name
-	}
-	return name
+func convertGopkgNameToPurl(name string) (rename string) {
+	rename = "golang/" + name
+	return
 }

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -17,6 +17,7 @@ import "regexp"
 
 var gopkg1Pattern = regexp.MustCompile("^gopkg.in/([^.]+).*")
 var gopkg2Pattern = regexp.MustCompile("^gopkg.in/([^/]+)/([^.]+).*")
+var githubPattern = regexp.MustCompile("^github.com/([^/]+)/([^/]+).*")
 
 // Packages is meant to be implemented for any package format such as dep, go mod, etc..
 type Packages interface {
@@ -29,6 +30,8 @@ type Packages interface {
 // FIXME: Research the various Gopkg name formats and convert them correctly
 func convertGopkgNameToPurl(name string) (rename string) {
 	switch {
+	case githubPattern.MatchString(name):
+		rename = githubPattern.ReplaceAllString(name, "golang/$1/$2")
 	case gopkg2Pattern.MatchString(name):
 		rename = gopkg2Pattern.ReplaceAllString(name, "golang/$1/$2")
 	case gopkg1Pattern.MatchString(name):

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -30,9 +30,9 @@ type Packages interface {
 func convertGopkgNameToPurl(name string) (rename string) {
 	switch {
 	case gopkg2Pattern.MatchString(name):
-		rename = gopkg2Pattern.ReplaceAllString(name, "github/$1/$2")
+		rename = gopkg2Pattern.ReplaceAllString(name, "golang/$1/$2")
 	case gopkg1Pattern.MatchString(name):
-		rename = gopkg1Pattern.ReplaceAllString(name, "github/go-$1/$1")
+		rename = gopkg1Pattern.ReplaceAllString(name, "golang/go-$1/$1")
 	default:
 		rename = "golang/" + name
 	}

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -13,6 +13,11 @@
 // limitations under the License.
 package packages
 
+import "regexp"
+
+var gopkg1Pattern = regexp.MustCompile("^gopkg.in/([^.]+).*")
+var gopkg2Pattern = regexp.MustCompile("^gopkg.in/([^/]+)/([^.]+).*")
+
 // Packages is meant to be implemented for any package format such as dep, go mod, etc..
 type Packages interface {
 	ExtractPurlsFromManifest() []string
@@ -23,6 +28,13 @@ type Packages interface {
 //
 // FIXME: Research the various Gopkg name formats and convert them correctly
 func convertGopkgNameToPurl(name string) (rename string) {
-	rename = "golang/" + name
+	switch {
+	case gopkg2Pattern.MatchString(name):
+		rename = gopkg2Pattern.ReplaceAllString(name, "github/$1/$2")
+	case gopkg1Pattern.MatchString(name):
+		rename = gopkg1Pattern.ReplaceAllString(name, "github/go-$1/$1")
+	default:
+		rename = "golang/" + name
+	}
 	return
 }

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -17,7 +17,7 @@ import "regexp"
 
 var gopkg1Pattern = regexp.MustCompile("^gopkg.in/([^.]+).*")
 var gopkg2Pattern = regexp.MustCompile("^gopkg.in/([^/]+)/([^.]+).*")
-var githubPattern = regexp.MustCompile("^github.com/([^/]+)/([^/]+).*")
+var githubPattern = regexp.MustCompile("^github.com/([^/]+)/(.*)")
 
 // Packages is meant to be implemented for any package format such as dep, go mod, etc..
 type Packages interface {
@@ -31,11 +31,11 @@ type Packages interface {
 func convertGopkgNameToPurl(name string) (rename string) {
 	switch {
 	case githubPattern.MatchString(name):
-		rename = githubPattern.ReplaceAllString(name, "golang/$1/$2")
+		rename = githubPattern.ReplaceAllString(name, "golang/github.com/$1/$2")
 	case gopkg2Pattern.MatchString(name):
-		rename = gopkg2Pattern.ReplaceAllString(name, "golang/$1/$2")
+		rename = gopkg2Pattern.ReplaceAllString(name, "golang/github.com/$1/$2")
 	case gopkg1Pattern.MatchString(name):
-		rename = gopkg1Pattern.ReplaceAllString(name, "golang/go-$1/$1")
+		rename = gopkg1Pattern.ReplaceAllString(name, "golang/github.com/go-$1/$1")
 	default:
 		rename = "golang/" + name
 	}

--- a/packages/packages_test.go
+++ b/packages/packages_test.go
@@ -18,10 +18,11 @@ import (
 )
 
 const (
-	GolangResult   = "golang/golang.org/x/net"
-	GitHubResult   = "golang/sonatype-nexus-community/nancy"
-	GoPkgIn1Result = "golang/go-name/name"
-	GoPkgIn2Result = "golang/owner/name"
+	GolangResult        = "golang/golang.org/x/net"
+	GitHubResult        = "golang/github.com/sonatype-nexus-community/nancy"
+	GitHubSubPathResult = "golang/github.com/subutai-io/base/agent/lib/net/p2p"
+	GoPkgIn1Result      = "golang/github.com/go-name/name"
+	GoPkgIn2Result      = "golang/github.com/owner/name"
 )
 
 func TestConvertGopkgNameToPurl(t *testing.T) {
@@ -48,4 +49,10 @@ func TestConvertGopkgNameToPurl(t *testing.T) {
 	if result != GoPkgIn2Result {
 		t.Errorf("Conversion did not work, got back %s, but expected %s", result, GoPkgIn2Result)
 	}
+
+	result = convertGopkgNameToPurl("github.com/subutai-io/base/agent/lib/net/p2p")
+	if result != GitHubSubPathResult {
+		t.Errorf("Conversion did not work, got back %s, but expected %s", result, GoPkgIn2Result)
+	}
+
 }

--- a/packages/packages_test.go
+++ b/packages/packages_test.go
@@ -19,9 +19,9 @@ import (
 
 const (
 	GolangResult   = "golang/golang.org/x/net"
-	GitHubResult   = "github/sonatype-nexus-community/nancy"
-	GoPkgIn1Result = "github/go-name/name"
-	GoPkgIn2Result = "github/owner/name"
+	GitHubResult   = "golang/sonatype-nexus-community/nancy"
+	GoPkgIn1Result = "golang/go-name/name"
+	GoPkgIn2Result = "golang/owner/name"
 )
 
 func TestConvertGopkgNameToPurl(t *testing.T) {


### PR DESCRIPTION
Basically, OSS Index works now with just `golang/` so let's do that!

This pull request makes the following changes:
* Update `packages/packages.go` to do what it was doing, but just use `golang/` now!
* Update RegEx on the GitHubPattern to now match submodules, making Nancy more useful!
* Minor display tweaks that @jdillon brought up
