### PR TITLE
Initial work for CVE exclude list flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,19 +16,22 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/sonatype-nexus-community/nancy/audit"
 	"github.com/sonatype-nexus-community/nancy/buildversion"
 	"github.com/sonatype-nexus-community/nancy/customerrors"
 	"github.com/sonatype-nexus-community/nancy/ossindex"
 	"github.com/sonatype-nexus-community/nancy/packages"
 	"github.com/sonatype-nexus-community/nancy/parse"
-	"os"
-	"strings"
+	"github.com/sonatype-nexus-community/nancy/types"
 )
 
 var noColorPtr *bool
 var quietPtr *bool
 var path string
+var cveList types.CveListFlag
 
 func main() {
 	args := os.Args[1:]
@@ -36,6 +39,7 @@ func main() {
 	noColorPtr = flag.Bool("noColor", false, "indicate output should not be colorized")
 	quietPtr = flag.Bool("quiet", false, "indicate output should contain only packages with vulnerabilities")
 	version := flag.Bool("version", false, "prints current nancy version")
+	flag.Var(&cveList, "exclude", "Comma seperated list of CVEs to exclude")
 
 	flag.Usage = func() {
 		_, _ = fmt.Fprintf(os.Stderr, "Usage: \nnancy [options] </path/to/Gopkg.lock>\nnancy [options] </path/to/go.sum>\n\nOptions:\n")

--- a/types/types.go
+++ b/types/types.go
@@ -14,6 +14,9 @@
 package types
 
 import (
+	"fmt"
+	"strings"
+
 	decimal "github.com/shopspring/decimal"
 )
 
@@ -43,4 +46,21 @@ type Projects struct {
 }
 type ProjectList struct {
 	Projects []Projects
+}
+
+type CveListFlag struct {
+	cves []string
+}
+
+func (cve *CveListFlag) String() string {
+	return fmt.Sprint(cve.cves)
+}
+
+func (cve *CveListFlag) Set(value string) error {
+	if len(cve.cves) > 0 {
+		return fmt.Errorf("The CVE Exclude Flag is already set")
+	}
+	cve.cves = strings.Split(value, ",")
+
+	return nil
 }


### PR DESCRIPTION
This PR aims to provide a way to provide a list of CVEs that you want to mark as "safe" essentially, and not cause Nancy to fail. 

This pull request makes the following changes:
* New type that implements `flag.Value`
* Implementation of `exclude` flag

After finishing this PR, one would be able to run `./nancy -exclude CVE123,CVE456` and have it ignore those vulnerabilities (likely by telling you they were ignored, too). 

It relates to the following issue #s:
* Fixes #16 

cc @bhamail / @DarthHater
