### PR TITLE
CVE exclusion file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,22 @@ You can run `nancy` in a quiet manner, only getting back a list of vulnerable co
 Sometimes you'll run into a dependency that after taking a look at, you either aren't affected by, or cannot resolve for some reason. Nancy understands, and will let you 
 exclude these vulnerabilities so you can get back to a passing build:
 
+Vulnerabilities excluded will then be silenced and not show up in the output or fail your build.
+
+We support exclusion of vulnerability either by CVE-ID (ex: `CVE-2018-20303`) or via the OSS Index ID (ex: `a8c20c84-1f6a-472a-ba1b-3eaedb2a2a14`) as not all vulnerabilities have a CVE-ID.
+
+##### Via CLI flag
 * `./nancy -exclude-vulnerability CVE-789,bcb0c38d-0d35-44ee-b7a7-8f77183d1ae2 /path/to/your/Gopkg.lock`
 * `./nancy -exclude-vulnerability CVE-789,bcb0c38d-0d35-44ee-b7a7-8f77183d1ae2 /path/to/your/go.sum`
 
-Vulnerabiliites excluded will then be silenced and not show up in the output or fail your build.
+##### Via file
+By default if a file named `exclude_vulnerabilities` exists in the same directory that nancy is run it will use it, will no other options need to be passed.
 
-We support exclusion of vulnerability either by CVE-ID (ex: `CVE-2018-20303`) or via the OSS Index ID (ex: `a8c20c84-1f6a-472a-ba1b-3eaedb2a2a14`) as not all vulnerabilities have a CVE-ID.
+If you would like to define the path to the file you can use the following
+* `./nancy -exclude-vulnerability-file=/path/to/your/exclude-file /path/to/your/Gopkg.lock`
+* `./nancy -exclude-vulnerability-file=/path/to/your/exclude-file /path/to/your/go.sum`  
+
+The file format requires each vulnerability that you want to exclude to be on a separate line. 
 
 ### Usage in CI
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We support exclusion of vulnerability either by CVE-ID (ex: `CVE-2018-20303`) or
 * `./nancy -exclude-vulnerability CVE-789,bcb0c38d-0d35-44ee-b7a7-8f77183d1ae2 /path/to/your/go.sum`
 
 ##### Via file
-By default if a file named `exclude_vulnerabilities` exists in the same directory that nancy is run it will use it, will no other options need to be passed.
+By default if a file named `.nancy-ignore` exists in the same directory that nancy is run it will use it, will no other options need to be passed.
 
 If you would like to define the path to the file you can use the following
 * `./nancy -exclude-vulnerability-file=/path/to/your/exclude-file /path/to/your/Gopkg.lock`

--- a/configuration/parse.go
+++ b/configuration/parse.go
@@ -1,11 +1,13 @@
 package configuration
 
 import (
+	"bufio"
 	"errors"
 	"flag"
 	"fmt"
 	"github.com/sonatype-nexus-community/nancy/types"
 	"os"
+	"strings"
 )
 
 type Configuration struct {
@@ -14,18 +16,19 @@ type Configuration struct {
 	Quiet bool
 	Version bool
 	CveList types.CveListFlag
-	Path string
+	Path    string
 }
 
-
-func Parse(args []string) (Configuration, error){
+func Parse(args []string) (Configuration, error) {
 	config := Configuration{}
+	var excludeVulnerabilityFilePath string
 
 	flag.BoolVar(&config.NoColor, "no-color", false, "indicate output should not be colorized")
 	flag.BoolVar(&config.NoColorDeprecated, "noColor", false, "indicate output should not be colorized (deprecated: please use no-color)")
-	flag.BoolVar(&config.Quiet,"quiet", false, "indicate output should contain only packages with vulnerabilities")
-	flag.BoolVar(&config.Version,"version", false, "prints current nancy version")
-	flag.Var(&config.CveList, "exclude-vulnerability", "Comma seperated list of CVEs to exclude")
+	flag.BoolVar(&config.Quiet, "quiet", false, "indicate output should contain only packages with vulnerabilities")
+	flag.BoolVar(&config.Version, "version", false, "prints current nancy version")
+	flag.Var(&config.CveList, "exclude-vulnerability", "Comma separated list of CVEs to exclude")
+	flag.StringVar(&excludeVulnerabilityFilePath, "exclude-vulnerability-file", "./exclude_vulnerabilities", "Path to a file containing newline separated CVEs to be excluded")
 
 	flag.Usage = func() {
 		_, _ = fmt.Fprintf(os.Stderr, "Usage: \nnancy [options] </path/to/Gopkg.lock>\nnancy [options] </path/to/go.sum>\n\nOptions:\n")
@@ -44,5 +47,36 @@ func Parse(args []string) (Configuration, error){
 	}
 	config.Path = args[len(args)-1]
 
+	err = getCVEExcludesFromFile(&config, excludeVulnerabilityFilePath)
+	if err != nil {
+		return config, err
+	}
+
 	return config, nil
+}
+
+func getCVEExcludesFromFile(config *Configuration, excludeVulnerabilityFilePath string) error {
+	fi, err := os.Stat(excludeVulnerabilityFilePath)
+	if (fi != nil && fi.IsDir()) || (err != nil && os.IsNotExist(err)) {
+		return nil
+	}
+	file, err := os.Open(excludeVulnerabilityFilePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if len(line) > 0 {
+			config.CveList.Cves = append(config.CveList.Cves, line)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/configuration/parse.go
+++ b/configuration/parse.go
@@ -12,7 +12,6 @@ import (
 
 type Configuration struct {
 	NoColor bool
-	NoColorDeprecated bool
 	Quiet bool
 	Version bool
 	CveList types.CveListFlag
@@ -22,9 +21,10 @@ type Configuration struct {
 func Parse(args []string) (Configuration, error) {
 	config := Configuration{}
 	var excludeVulnerabilityFilePath string
+	var noColorDeprecated bool
 
 	flag.BoolVar(&config.NoColor, "no-color", false, "indicate output should not be colorized")
-	flag.BoolVar(&config.NoColorDeprecated, "noColor", false, "indicate output should not be colorized (deprecated: please use no-color)")
+	flag.BoolVar(&noColorDeprecated, "noColor", false, "indicate output should not be colorized (deprecated: please use no-color)")
 	flag.BoolVar(&config.Quiet, "quiet", false, "indicate output should contain only packages with vulnerabilities")
 	flag.BoolVar(&config.Version, "version", false, "prints current nancy version")
 	flag.Var(&config.CveList, "exclude-vulnerability", "Comma separated list of CVEs to exclude")
@@ -46,6 +46,13 @@ func Parse(args []string) (Configuration, error) {
 		return config, err
 	}
 	config.Path = args[len(args)-1]
+
+	if noColorDeprecated == true {
+		fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+		fmt.Println("!!!! DEPRECATION WARNING : Please change 'noColor' param to be 'no-color'. This one will be removed in a future release. !!!!")
+		fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+		config.NoColor = noColorDeprecated
+	}
 
 	err = getCVEExcludesFromFile(&config, excludeVulnerabilityFilePath)
 	if err != nil {

--- a/configuration/parse.go
+++ b/configuration/parse.go
@@ -28,7 +28,7 @@ func Parse(args []string) (Configuration, error) {
 	flag.BoolVar(&config.Quiet, "quiet", false, "indicate output should contain only packages with vulnerabilities")
 	flag.BoolVar(&config.Version, "version", false, "prints current nancy version")
 	flag.Var(&config.CveList, "exclude-vulnerability", "Comma separated list of CVEs to exclude")
-	flag.StringVar(&excludeVulnerabilityFilePath, "exclude-vulnerability-file", "./exclude_vulnerabilities", "Path to a file containing newline separated CVEs to be excluded")
+	flag.StringVar(&excludeVulnerabilityFilePath, "exclude-vulnerability-file", "./.nancy-ignore", "Path to a file containing newline separated CVEs to be excluded")
 
 	flag.Usage = func() {
 		_, _ = fmt.Fprintf(os.Stderr, "Usage: \nnancy [options] </path/to/Gopkg.lock>\nnancy [options] </path/to/go.sum>\n\nOptions:\n")

--- a/configuration/parse.go
+++ b/configuration/parse.go
@@ -1,0 +1,48 @@
+package configuration
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"github.com/sonatype-nexus-community/nancy/types"
+	"os"
+)
+
+type Configuration struct {
+	NoColor bool
+	NoColorDeprecated bool
+	Quiet bool
+	Version bool
+	CveList types.CveListFlag
+	Path string
+}
+
+
+func Parse(args []string) (Configuration, error){
+	config := Configuration{}
+
+	flag.BoolVar(&config.NoColor, "no-color", false, "indicate output should not be colorized")
+	flag.BoolVar(&config.NoColorDeprecated, "noColor", false, "indicate output should not be colorized (deprecated: please use no-color)")
+	flag.BoolVar(&config.Quiet,"quiet", false, "indicate output should contain only packages with vulnerabilities")
+	flag.BoolVar(&config.Version,"version", false, "prints current nancy version")
+	flag.Var(&config.CveList, "exclude-vulnerability", "Comma seperated list of CVEs to exclude")
+
+	flag.Usage = func() {
+		_, _ = fmt.Fprintf(os.Stderr, "Usage: \nnancy [options] </path/to/Gopkg.lock>\nnancy [options] </path/to/go.sum>\n\nOptions:\n")
+		flag.PrintDefaults()
+		os.Exit(2)
+	}
+
+	if len(args) < 1 {
+		return config, errors.New("no arguments passed")
+	}
+
+	// Parse config from the command line output
+	err := flag.CommandLine.Parse(args)
+	if err != nil {
+		return config, err
+	}
+	config.Path = args[len(args)-1]
+
+	return config, nil
+}

--- a/configuration/parse_test.go
+++ b/configuration/parse_test.go
@@ -28,7 +28,8 @@ func TestConfigParse(t *testing.T) {
 		expectedErr    error
 	}{
 		"defaults":                               {args: []string{"/tmp/go.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go.sum"}, expectedErr: nil},
-		"no color":                               {args: []string{"-noColor", "/tmp/go2.sum"}, expectedConfig: Configuration{NoColor: true, Quiet: false, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go2.sum"}, expectedErr: nil},
+		"no color":                               {args: []string{"-no-color", "/tmp/go2.sum"}, expectedConfig: Configuration{NoColor: true, Quiet: false, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go2.sum"}, expectedErr: nil},
+		"no color (deprecated)":                  {args: []string{"-noColor", "/tmp/go2.sum"}, expectedConfig: Configuration{NoColor: true, Quiet: false, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go2.sum"}, expectedErr: nil},
 		"quiet":                                  {args: []string{"-quiet", "/tmp/go3.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: true, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go3.sum"}, expectedErr: nil},
 		"version":                                {args: []string{"-version", "/tmp/go4.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: true, CveList: types.CveListFlag{}, Path: "/tmp/go4.sum"}, expectedErr: nil},
 		"exclude vulnerabilities":                {args: []string{"-exclude-vulnerability=CVE123,CVE988", "/tmp/go5.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: false, CveList: types.CveListFlag{Cves: []string{"CVE123", "CVE988"}}, Path: "/tmp/go5.sum"}, expectedErr: nil},

--- a/configuration/parse_test.go
+++ b/configuration/parse_test.go
@@ -48,7 +48,7 @@ func TestConfigParse(t *testing.T) {
 			setup()
 
 			if name == "exclude vulnerabilities doesn't need to be passed if default value is used" {
-				defaultFileName := "exclude_vulnerabilities"
+				defaultFileName := ".nancy-ignore"
 				err := ioutil.WriteFile(defaultFileName, []byte("DEF-111\nDEF-222"), 0644)
 				if err != nil {
 					t.Fatal(err)

--- a/configuration/parse_test.go
+++ b/configuration/parse_test.go
@@ -1,0 +1,39 @@
+package configuration
+
+import (
+	"errors"
+	"flag"
+	"github.com/sonatype-nexus-community/nancy/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestConfigParse(t *testing.T) {
+	tests := map[string]struct {
+		args           []string
+		expectedConfig Configuration
+		expectedErr    error
+	}{
+		"defaults":                {args: []string{"/tmp/go.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go.sum"}, expectedErr: nil},
+		"no color":                {args: []string{"-noColor", "/tmp/go2.sum"}, expectedConfig: Configuration{NoColor: true, Quiet: false, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go2.sum"}, expectedErr: nil},
+		"quiet":                   {args: []string{"-quiet", "/tmp/go3.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: true, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go3.sum"}, expectedErr: nil},
+		"version":                 {args: []string{"-version", "/tmp/go4.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: true, CveList: types.CveListFlag{}, Path: "/tmp/go4.sum"}, expectedErr: nil},
+		"exclude vulnerabilities": {args: []string{"-exclude-vulnerability=CVE123,CVE988", "/tmp/go5.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: false, CveList: types.CveListFlag{Cves:[]string{"CVE123", "CVE988"}}, Path: "/tmp/go5.sum"}, expectedErr: nil},
+		"no args": {args: []string{}, expectedConfig: Configuration{}, expectedErr: errors.New("no arguments passed")},
+		"path but invalid arg": {args: []string{"-invalid", "/tmp/go6.sum"}, expectedConfig: Configuration{}, expectedErr: errors.New("flag provided but not defined: -invalid")},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			setup()
+
+			actualConfig, actualErr := Parse(test.args)
+			assert.Equal(t, test.expectedErr, actualErr)
+			assert.Equal(t, test.expectedConfig, actualConfig)
+		})
+	}
+}
+
+func setup() {
+	flag.CommandLine = flag.NewFlagSet("", flag.ContinueOnError)
+}

--- a/configuration/parse_test.go
+++ b/configuration/parse_test.go
@@ -1,37 +1,83 @@
 package configuration
 
 import (
+	"bufio"
 	"errors"
 	"flag"
 	"github.com/sonatype-nexus-community/nancy/types"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
 	"testing"
 )
 
 func TestConfigParse(t *testing.T) {
+	file := setupCVEExcludeFile(t, "CVF-000\nCVF-123\nCVF-9999")
+	emptyFile := setupCVEExcludeFile(t, "")
+	lotsOfRandomNewlinesFile := setupCVEExcludeFile(t, "\n\nCVN-111\n\n\nCVN-123\nCVN-543\n\n")
+	dir, _ := ioutil.TempDir("", "prefix")
+
+	defer os.Remove(file.Name())
+	defer os.Remove(emptyFile.Name())
+	defer os.Remove(lotsOfRandomNewlinesFile.Name())
+	defer os.Remove(dir)
+
 	tests := map[string]struct {
 		args           []string
 		expectedConfig Configuration
 		expectedErr    error
 	}{
-		"defaults":                {args: []string{"/tmp/go.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go.sum"}, expectedErr: nil},
-		"no color":                {args: []string{"-noColor", "/tmp/go2.sum"}, expectedConfig: Configuration{NoColor: true, Quiet: false, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go2.sum"}, expectedErr: nil},
-		"quiet":                   {args: []string{"-quiet", "/tmp/go3.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: true, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go3.sum"}, expectedErr: nil},
-		"version":                 {args: []string{"-version", "/tmp/go4.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: true, CveList: types.CveListFlag{}, Path: "/tmp/go4.sum"}, expectedErr: nil},
-		"exclude vulnerabilities": {args: []string{"-exclude-vulnerability=CVE123,CVE988", "/tmp/go5.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: false, CveList: types.CveListFlag{Cves:[]string{"CVE123", "CVE988"}}, Path: "/tmp/go5.sum"}, expectedErr: nil},
-		"no args": {args: []string{}, expectedConfig: Configuration{}, expectedErr: errors.New("no arguments passed")},
-		"path but invalid arg": {args: []string{"-invalid", "/tmp/go6.sum"}, expectedConfig: Configuration{}, expectedErr: errors.New("flag provided but not defined: -invalid")},
+		"defaults":                               {args: []string{"/tmp/go.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go.sum"}, expectedErr: nil},
+		"no color":                               {args: []string{"-noColor", "/tmp/go2.sum"}, expectedConfig: Configuration{NoColor: true, Quiet: false, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go2.sum"}, expectedErr: nil},
+		"quiet":                                  {args: []string{"-quiet", "/tmp/go3.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: true, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go3.sum"}, expectedErr: nil},
+		"version":                                {args: []string{"-version", "/tmp/go4.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: true, CveList: types.CveListFlag{}, Path: "/tmp/go4.sum"}, expectedErr: nil},
+		"exclude vulnerabilities":                {args: []string{"-exclude-vulnerability=CVE123,CVE988", "/tmp/go5.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: false, CveList: types.CveListFlag{Cves: []string{"CVE123", "CVE988"}}, Path: "/tmp/go5.sum"}, expectedErr: nil},
+		"no args":                                {args: []string{}, expectedConfig: Configuration{}, expectedErr: errors.New("no arguments passed")},
+		"path but invalid arg":                   {args: []string{"-invalid", "/tmp/go6.sum"}, expectedConfig: Configuration{}, expectedErr: errors.New("flag provided but not defined: -invalid")},
+		"exclude vulnerabilities with sane file": {args: []string{"-exclude-vulnerability-file=" + file.Name(), "/tmp/go7.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{Cves: []string{"CVF-000", "CVF-123", "CVF-9999"}}, Path: "/tmp/go7.sum"}, expectedErr: nil},
+		"exclude vulnerabilities when file empty":                                    {args: []string{"-exclude-vulnerability-file=" + emptyFile.Name(), "/tmp/go8.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{}, Path: "/tmp/go8.sum"}, expectedErr: nil},
+		"exclude vulnerabilities when file has tons of newlines":                     {args: []string{"-exclude-vulnerability-file=" + lotsOfRandomNewlinesFile.Name(), "/tmp/go9.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{Cves: []string{"CVN-111", "CVN-123", "CVN-543"}}, Path: "/tmp/go9.sum"}, expectedErr: nil},
+		"exclude vulnerabilities are combined with file and args values":             {args: []string{"-exclude-vulnerability=CVE123,CVE988", "-exclude-vulnerability-file=" + lotsOfRandomNewlinesFile.Name(), "/tmp/go10.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{Cves: []string{"CVE123", "CVE988", "CVN-111", "CVN-123", "CVN-543"}}, Path: "/tmp/go10.sum"}, expectedErr: nil},
+		"exclude vulnerabilities file not found doesn't matter":                      {args: []string{"-exclude-vulnerability-file=/blah-blah-doesnt-exists", "/tmp/go11.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{}, Path: "/tmp/go11.sum"}, expectedErr: nil},
+		"exclude vulnerabilities passed as directory doesn't matter":                 {args: []string{"-exclude-vulnerability-file=" + dir, "/tmp/go12.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{}, Path: "/tmp/go12.sum"}, expectedErr: nil},
+		"exclude vulnerabilities doesn't need to be passed if default value is used": {args: []string{"/tmp/go13.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{Cves: []string{"DEF-111","DEF-222"}}, Path: "/tmp/go13.sum"}, expectedErr: nil},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			setup()
 
+			if name == "exclude vulnerabilities doesn't need to be passed if default value is used" {
+				defaultFileName := "exclude_vulnerabilities"
+				err := ioutil.WriteFile(defaultFileName, []byte("DEF-111\nDEF-222"), 0644)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer os.Remove(defaultFileName)
+			}
+
 			actualConfig, actualErr := Parse(test.args)
 			assert.Equal(t, test.expectedErr, actualErr)
 			assert.Equal(t, test.expectedConfig, actualConfig)
 		})
 	}
+}
+
+func setupCVEExcludeFile(t *testing.T, fileContents string) (file *os.File) {
+	file, err := ioutil.TempFile("", "prefix")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := bufio.NewWriter(file)
+	_, err = w.WriteString(fileContents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = w.Flush()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return file
 }
 
 func setup() {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7 // indirect
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Flaque/filet v0.0.0-20190209224823-fc4d33cfcf93
-	github.com/Masterminds/semver v0.0.0-20180403130225-3c92f33da7a8 // indirect
+	github.com/Masterminds/semver v0.0.0-20180403130225-3c92f33da7a8
 	github.com/Masterminds/vcs v1.13.1 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect

--- a/main.go
+++ b/main.go
@@ -16,62 +16,35 @@ package main
 import (
 	"flag"
 	"fmt"
-	"os"
-	"strings"
 	"github.com/golang/dep"
 	"github.com/sonatype-nexus-community/nancy/audit"
 	"github.com/sonatype-nexus-community/nancy/buildversion"
+	"github.com/sonatype-nexus-community/nancy/configuration"
 	"github.com/sonatype-nexus-community/nancy/customerrors"
 	"github.com/sonatype-nexus-community/nancy/ossindex"
 	"github.com/sonatype-nexus-community/nancy/packages"
 	"github.com/sonatype-nexus-community/nancy/parse"
-	"github.com/sonatype-nexus-community/nancy/types"
+	"os"
 	"path/filepath"
+	"strings"
 )
 
-var noColorPtr *bool
-var quietPtr *bool
-var path string
-var cveList types.CveListFlag
+var config configuration.Configuration
 
 func main() {
-	args := os.Args[1:]
-
-	noColorDepPtr := flag.Bool("noColor", false, "indicate output should not be colorized (deprecated: please use no-color)")
-	noColorPtr = flag.Bool("no-color", false, "indicate output should not be colorized")
-	quietPtr = flag.Bool("quiet", false, "indicate output should contain only packages with vulnerabilities")
-	version := flag.Bool("version", false, "prints current nancy version")
-	flag.Var(&cveList, "exclude-vulnerability", "Comma seperated list of CVEs to exclude")
-
-	flag.Usage = func() {
-		_, _ = fmt.Fprintf(os.Stderr, "Usage: \nnancy [options] </path/to/Gopkg.lock>\nnancy [options] </path/to/go.sum>\n\nOptions:\n")
-		flag.PrintDefaults()
-		os.Exit(2)
-	}
-
-	if len(args) < 1 {
+	var err error
+	config, err = configuration.Parse(os.Args[1:])
+	if err != nil {
 		flag.Usage()
 		os.Exit(1)
 	}
 
-	// Parse flags from the command line output
-	flag.Parse()
-
-	if *noColorDepPtr == true {
-		fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-		fmt.Println("!!!! DEPRECATION WARNING : Please change 'noColor' param to be 'no-color'. This one will be removed in a future release. !!!!")
-		fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-		noColorPtr = noColorDepPtr
-	}
-
-	if *version {
+	if config.Version {
 		fmt.Println(buildversion.BuildVersion)
 		_, _ = fmt.Printf("build time: %s\n", buildversion.BuildTime)
 		_, _ = fmt.Printf("build commit: %s\n", buildversion.BuildCommit)
 		os.Exit(0)
 	}
-
-	path = args[len(args)-1]
 
 	// Currently only checks Dep, can eventually check for go mod, etc...
 	doCheckExistenceAndParse()
@@ -79,8 +52,8 @@ func main() {
 
 func doCheckExistenceAndParse() {
 	switch {
-	case strings.Contains(path, "Gopkg.lock"):
-		workingDir := filepath.Dir(path)
+	case strings.Contains(config.Path, "Gopkg.lock"):
+		workingDir := filepath.Dir(config.Path)
 		if workingDir == "." {
 			workingDir, _ = os.Getwd()
 		}
@@ -91,21 +64,21 @@ func doCheckExistenceAndParse() {
 		}
 		project, err := ctx.LoadProject()
 		if err != nil {
-			customerrors.Check(err, fmt.Sprint("could not read lock at path "+path))
+			customerrors.Check(err, fmt.Sprint("could not read lock at path "+config.Path))
 		}
 
 		purls, invalidPurls := packages.ExtractPurlsUsingDep(*project)
 		if len(invalidPurls) > 0 {
-			audit.LogInvalidSemVerWarning(*noColorPtr, *quietPtr, invalidPurls)
+			audit.LogInvalidSemVerWarning(config.NoColor, config.Quiet, invalidPurls)
 		}
 
 		var packageCount = len(purls)
 		checkOSSIndex(purls, packageCount)
-	case strings.Contains(path, "go.sum"):
+	case strings.Contains(config.Path, "go.sum"):
 		mod := packages.Mod{}
-		mod.GoSumPath = path
+		mod.GoSumPath = config.Path
 		if mod.CheckExistenceOfManifest() {
-			mod.ProjectList, _ = parse.GoSum(path)
+			mod.ProjectList, _ = parse.GoSum(config.Path)
 			var purls = mod.ExtractPurlsFromManifest()
 			var packageCount = len(purls)
 
@@ -120,7 +93,7 @@ func checkOSSIndex(purls []string, packageCount int) {
 	coordinates, err := ossindex.AuditPackages(purls)
 	customerrors.Check(err, "Error auditing packages")
 
-	if count := audit.LogResults(*noColorPtr, *quietPtr, packageCount, coordinates, cveList.Cves); count > 0 {
+	if count := audit.LogResults(config.NoColor, config.Quiet, packageCount, coordinates, config.CveList.Cves); count > 0 {
 		os.Exit(count)
 	}
 }


### PR DESCRIPTION
Add the ability to exclude CVE using a file. If a file named `exclude_vulnerabilities` is defined in the directory that nancy is running it will be used. You also have the option to pass in the path of said exclude file by using cli flag `-exclude-vulnerability-file`. This also has the ability be used with the other cli flag of `exclude-vulnerability` since all the vulnerabilities are just added to a list.

As part of this change I refactored the flag parsing out of main since i need to add more logic to do the file processing. This also made the change easier to test. Only thing I felt like could be done is the `Configuration` struct that was created should that maybe go under `types` and not embedded in the `configuration/parse.go`??

It relates to the following issue #s:
* Fixes #31

cc @bhamail / @DarthHater
