### PR TITLE
Fix go get issue

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -57,11 +57,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:be40f095cd741773905744f16c1f7a21fd9226ccd0529f019deb7da6d667f71c"
+  digest = "1:9aaab932241543f719cd66e365a499956772e1f419a27aee2bb7bc3bf35af24a"
   name = "github.com/logrusorgru/aurora"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a7b3b318ed4e1ae5b80602b08627267303c68572"
+  revision = "94edacc10f9bc12e9ac613b16125c6c68a8f7626"
 
 [[projects]]
   digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"

--- a/audit/auditlog.go
+++ b/audit/auditlog.go
@@ -29,7 +29,7 @@ func logPackage(noColor bool, idx int, packageCount int, coordinate types.Coordi
 	} else {
 		fmt.Println("["+strconv.Itoa(idx)+"/"+strconv.Itoa(packageCount)+"]",
 			aurora.Bold(coordinate.Coordinates),
-			aurora.Gray("   No known vulnerabilities against package/version"))
+			aurora.Gray(20-1,"   No known vulnerabilities against package/version"))
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dgryski/go-farm v0.0.0-20180109070241-2de33835d102 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/golang/protobuf v1.2.0 // indirect
-	github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e
+	github.com/logrusorgru/aurora v0.0.0-20190803045625-94edacc10f9b
 	github.com/pkg/errors v0.8.0 // indirect
 	github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e h1:9MlwzLdW7QSDrhDjFlsEYmxpFyIoXmYRon3dt0io31k=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
+github.com/logrusorgru/aurora v0.0.0-20190803045625-94edacc10f9b h1:PMbSa9CgaiQR9NLlUTwKi+7aeLl3GG5JX5ERJxfQ3IE=
+github.com/logrusorgru/aurora v0.0.0-20190803045625-94edacc10f9b/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Update version of aurora to fix go get
Running this as i understand it
go get -u github.com/sonatype-nexus-community/nancy

Will ignore any dependency that is defined/locked and will not respect that version unless the dependency is included directly in your project.
https://github.com/golang/dep/blob/master/docs/FAQ.md#why-is-dep-ignoring-a-version-constraint-in-the-manifest

So basically by using just go get it was pulling latest master of aurora and they had changed
the method signature of Gray.

To fix this just simply updated aurora and updated the one method call to Gray

It relates to the following issue #s:
* Fixes #37 

cc @bhamail / @DarthHater
