### PR TITLE
Allow go list -m all via std in 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
   - GOOS=windows GOARCH=amd64 go build -ldflags="-X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildVersion=$VERSION' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildTime=$time' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildCommit=$TRAVIS_COMMIT'" -o nancy-windows.amd64-$VERSION.exe
   - ./nancy-linux.amd64-$VERSION Gopkg.lock
   - ./nancy-linux.amd64-$VERSION go.sum
+  - go list -m all | ./nancy-linux.amd64-$VERSION
 env:
   - GO111MODULE=on
   - CGO_ENABLED=0

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 ```
  ~ > nancy
 Usage:
+go list -m all | nancy [options]
 nancy [options] </path/to/Gopkg.lock>
 nancy [options] </path/to/go.sum>
 

--- a/configuration/parse.go
+++ b/configuration/parse.go
@@ -2,7 +2,6 @@ package configuration
 
 import (
 	"bufio"
-	"errors"
 	"flag"
 	"fmt"
 	"github.com/sonatype-nexus-community/nancy/types"
@@ -11,6 +10,8 @@ import (
 )
 
 type Configuration struct {
+	UseStdIn bool
+	Help bool
 	NoColor bool
 	Quiet bool
 	Version bool
@@ -23,6 +24,7 @@ func Parse(args []string) (Configuration, error) {
 	var excludeVulnerabilityFilePath string
 	var noColorDeprecated bool
 
+	flag.BoolVar(&config.Help, "help", false, "provides help text on how to use nancy")
 	flag.BoolVar(&config.NoColor, "no-color", false, "indicate output should not be colorized")
 	flag.BoolVar(&noColorDeprecated, "noColor", false, "indicate output should not be colorized (deprecated: please use no-color)")
 	flag.BoolVar(&config.Quiet, "quiet", false, "indicate output should contain only packages with vulnerabilities")
@@ -36,16 +38,17 @@ func Parse(args []string) (Configuration, error) {
 		os.Exit(2)
 	}
 
-	if len(args) < 1 {
-		return config, errors.New("no arguments passed")
-	}
-
 	// Parse config from the command line output
 	err := flag.CommandLine.Parse(args)
 	if err != nil {
 		return config, err
 	}
-	config.Path = args[len(args)-1]
+
+	if len(flag.Args()) == 0 {
+		config.UseStdIn = true
+	}else{
+		config.Path = args[len(args)-1]
+	}
 
 	if noColorDeprecated == true {
 		fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")

--- a/configuration/parse_test.go
+++ b/configuration/parse_test.go
@@ -28,12 +28,13 @@ func TestConfigParse(t *testing.T) {
 		expectedErr    error
 	}{
 		"defaults":                               {args: []string{"/tmp/go.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go.sum"}, expectedErr: nil},
+		"help":                                   {args: []string{"-help", "/tmp/go2.sum"}, expectedConfig: Configuration{Help: true, NoColor: false, Quiet: false, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go2.sum"}, expectedErr: nil},
 		"no color":                               {args: []string{"-no-color", "/tmp/go2.sum"}, expectedConfig: Configuration{NoColor: true, Quiet: false, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go2.sum"}, expectedErr: nil},
 		"no color (deprecated)":                  {args: []string{"-noColor", "/tmp/go2.sum"}, expectedConfig: Configuration{NoColor: true, Quiet: false, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go2.sum"}, expectedErr: nil},
 		"quiet":                                  {args: []string{"-quiet", "/tmp/go3.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: true, Version: false, CveList: types.CveListFlag{}, Path: "/tmp/go3.sum"}, expectedErr: nil},
 		"version":                                {args: []string{"-version", "/tmp/go4.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: true, CveList: types.CveListFlag{}, Path: "/tmp/go4.sum"}, expectedErr: nil},
 		"exclude vulnerabilities":                {args: []string{"-exclude-vulnerability=CVE123,CVE988", "/tmp/go5.sum"}, expectedConfig: Configuration{NoColor: false, Quiet: false, Version: false, CveList: types.CveListFlag{Cves: []string{"CVE123", "CVE988"}}, Path: "/tmp/go5.sum"}, expectedErr: nil},
-		"no args":                                {args: []string{}, expectedConfig: Configuration{}, expectedErr: errors.New("no arguments passed")},
+		"std in as input":                        {args: []string{}, expectedConfig: Configuration{UseStdIn: true}, expectedErr: nil},
 		"path but invalid arg":                   {args: []string{"-invalid", "/tmp/go6.sum"}, expectedConfig: Configuration{}, expectedErr: errors.New("flag provided but not defined: -invalid")},
 		"exclude vulnerabilities with sane file": {args: []string{"-exclude-vulnerability-file=" + file.Name(), "/tmp/go7.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{Cves: []string{"CVF-000", "CVF-123", "CVF-9999"}}, Path: "/tmp/go7.sum"}, expectedErr: nil},
 		"exclude vulnerabilities when file empty":                                    {args: []string{"-exclude-vulnerability-file=" + emptyFile.Name(), "/tmp/go8.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{}, Path: "/tmp/go8.sum"}, expectedErr: nil},
@@ -41,7 +42,7 @@ func TestConfigParse(t *testing.T) {
 		"exclude vulnerabilities are combined with file and args values":             {args: []string{"-exclude-vulnerability=CVE123,CVE988", "-exclude-vulnerability-file=" + lotsOfRandomNewlinesFile.Name(), "/tmp/go10.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{Cves: []string{"CVE123", "CVE988", "CVN-111", "CVN-123", "CVN-543"}}, Path: "/tmp/go10.sum"}, expectedErr: nil},
 		"exclude vulnerabilities file not found doesn't matter":                      {args: []string{"-exclude-vulnerability-file=/blah-blah-doesnt-exists", "/tmp/go11.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{}, Path: "/tmp/go11.sum"}, expectedErr: nil},
 		"exclude vulnerabilities passed as directory doesn't matter":                 {args: []string{"-exclude-vulnerability-file=" + dir, "/tmp/go12.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{}, Path: "/tmp/go12.sum"}, expectedErr: nil},
-		"exclude vulnerabilities doesn't need to be passed if default value is used": {args: []string{"/tmp/go13.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{Cves: []string{"DEF-111","DEF-222"}}, Path: "/tmp/go13.sum"}, expectedErr: nil},
+		"exclude vulnerabilities doesn't need to be passed if default value is used": {args: []string{"/tmp/go13.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{Cves: []string{"DEF-111", "DEF-222"}}, Path: "/tmp/go13.sum"}, expectedErr: nil},
 	}
 
 	for name, test := range tests {

--- a/go.mod
+++ b/go.mod
@@ -26,3 +26,5 @@ require (
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
 	golang.org/x/sys v0.0.0-20181228144115-9a3f9b0469bb // indirect
 )
+
+go 1.13

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -22,7 +22,7 @@ import (
 
 func GoList(stdIn *bufio.Scanner) (deps types.ProjectList, err error) {
 	for stdIn.Scan() {
-		parseDep(stdIn, &deps)
+		parseGoModFormattedDependency(stdIn, &deps)
 	}
 	return deps, nil
 }
@@ -37,12 +37,13 @@ func GoSum(path string) (deps types.ProjectList, err error) {
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		parseDep(scanner, &deps)
+		parseGoModFormattedDependency(scanner, &deps)
 	}
 	return deps, nil
 }
 
-func parseDep(scanner *bufio.Scanner, deps *types.ProjectList) {
+// Parses a line of text that is in go.sum/go list -m all format. Which is basically just `<dep name> <version number>`
+func parseGoModFormattedDependency(scanner *bufio.Scanner, deps *types.ProjectList) {
 	text := scanner.Text()
 	s := strings.Split(text, " ")
 	if len(s) > 1 && !strings.HasSuffix(s[1], "/go.mod") {

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -20,6 +20,13 @@ import (
 	"strings"
 )
 
+func GoList(stdIn *bufio.Scanner) (deps types.ProjectList, err error) {
+	for stdIn.Scan() {
+		parseDep(stdIn, &deps)
+	}
+	return deps, nil
+}
+
 // GoSum parses the go.sum file and returns an error if unsuccessful
 func GoSum(path string) (deps types.ProjectList, err error) {
 	file, err := os.Open(path)
@@ -30,10 +37,15 @@ func GoSum(path string) (deps types.ProjectList, err error) {
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		s := strings.Split(scanner.Text(), " ")
-		if !strings.HasSuffix(s[1], "/go.mod") {
-			deps.Projects = append(deps.Projects, types.Projects{Name: s[0], Version: s[1]})
-		}
+		parseDep(scanner, &deps)
 	}
 	return deps, nil
+}
+
+func parseDep(scanner *bufio.Scanner, deps *types.ProjectList) {
+	text := scanner.Text()
+	s := strings.Split(text, " ")
+	if len(s) > 1 && !strings.HasSuffix(s[1], "/go.mod") {
+		deps.Projects = append(deps.Projects, types.Projects{Name: s[0], Version: s[1]})
+	}
 }

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -14,6 +14,8 @@
 package parse
 
 import (
+	"bufio"
+	"strings"
 	"testing"
 )
 
@@ -24,6 +26,36 @@ func TestGoSum(t *testing.T) {
 	}
 
 	if len(deps.Projects) != 10 {
+		t.Error(deps)
+	}
+}
+
+func TestGoListAll(t *testing.T) {
+	goListMAllOutput := `github.com/sonatype-nexus-community/nancy
+github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7
+github.com/BurntSushi/toml v0.3.1
+github.com/davecgh/go-spew v1.1.0
+github.com/dgraph-io/badger v1.5.5-0.20181004181505-439fd464b155
+github.com/dgryski/go-farm v0.0.0-20180109070241-2de33835d102
+github.com/dustin/go-humanize v1.0.0
+github.com/golang/protobuf v1.2.0
+github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e
+github.com/pkg/errors v0.8.0
+github.com/pmezard/go-difflib v1.0.0
+github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24
+github.com/stretchr/objx v0.1.0
+github.com/stretchr/testify v1.3.0
+golang.org/x/net v0.0.0-20181220203305-927f97764cc3
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4
+golang.org/x/sys v0.0.0-20181228144115-9a3f9b0469bb`
+	scanner := bufio.NewScanner(strings.NewReader(goListMAllOutput))
+
+	deps, err := GoList(scanner)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(deps.Projects) != 16 {
 		t.Error(deps)
 	}
 }


### PR DESCRIPTION
As it says, allows for sending in `go list -m all` via std in. Also since i had to tweaked the code and initially broke when usage would be printed if nothing was passed, i figured a `nancy -help` was in order but then realized I missed the location I actually needed to put the new usage call. So now it functions like it originally did but i left the new `help` flag b/c it cant hurt. 

It relates to the following issue #s:
* Fixes #42 

cc @bhamail / @DarthHater
