### PR TITLE
Update params to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ nancy [options] </path/to/go.sum>
 Options:
   -exclude-vulnerability value
     	Comma seperated list of CVEs to exclude
-  -noColor
+  -no-color
     	indicate output should not be colorized
+  -noColor
+    	indicate output should not be colorized (deprecated: please use no-color)
   -quiet
     	indicate output should contain only packages with vulnerabilities
   -version

--- a/main.go
+++ b/main.go
@@ -36,7 +36,8 @@ var cveList types.CveListFlag
 func main() {
 	args := os.Args[1:]
 
-	noColorPtr = flag.Bool("noColor", false, "indicate output should not be colorized")
+	noColorDepPtr := flag.Bool("noColor", false, "indicate output should not be colorized (deprecated: please use no-color)")
+	noColorPtr = flag.Bool("no-color", false, "indicate output should not be colorized")
 	quietPtr = flag.Bool("quiet", false, "indicate output should contain only packages with vulnerabilities")
 	version := flag.Bool("version", false, "prints current nancy version")
 	flag.Var(&cveList, "exclude-vulnerability", "Comma seperated list of CVEs to exclude")
@@ -54,6 +55,13 @@ func main() {
 
 	// Parse flags from the command line output
 	flag.Parse()
+
+	if *noColorDepPtr == true {
+		fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+		fmt.Println("!!!! DEPRECATION WARNING : Please change 'noColor' param to be 'no-color'. This one will be removed in a future release. !!!!")
+		fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+		noColorPtr = noColorDepPtr
+	}
 
 	if *version {
 		fmt.Println(buildversion.BuildVersion)


### PR DESCRIPTION
As mentioned in #26 where usage docs were updated and called out that the
params where using inconsistent casing.

Making the decision to go with lisp-case since it appears many other golang specific clis go with this casing for params.

Also only deprecating it for now, we can remove it in a later release. If used you will get a deprecation notice every time. Usage command and docs also call it out.  

cc @bhamail / @DarthHater
