### PR TITLE
Print out Nancy version

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,10 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/golang/dep"
 	"github.com/sonatype-nexus-community/nancy/audit"
 	"github.com/sonatype-nexus-community/nancy/buildversion"
@@ -25,9 +29,6 @@ import (
 	"github.com/sonatype-nexus-community/nancy/ossindex"
 	"github.com/sonatype-nexus-community/nancy/packages"
 	"github.com/sonatype-nexus-community/nancy/parse"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 var config configuration.Configuration
@@ -51,6 +52,8 @@ func main() {
 		_, _ = fmt.Printf("build commit: %s\n", buildversion.BuildCommit)
 		os.Exit(0)
 	}
+
+	fmt.Println("Nancy version: " + buildversion.BuildVersion)
 
 	if config.UseStdIn == true {
 		doStdInAndParse()

--- a/main.go
+++ b/main.go
@@ -53,7 +53,9 @@ func main() {
 		os.Exit(0)
 	}
 
-	fmt.Println("Nancy version: " + buildversion.BuildVersion)
+	if !config.Quiet {
+		fmt.Println("Nancy version: " + buildversion.BuildVersion)
+	}
 
 	if config.UseStdIn == true {
 		doStdInAndParse()


### PR DESCRIPTION
Shows Nancy version by default when you run

This pull request makes the following changes:
* Prints `buildversion.BuildVersion` in `main.go` before doing any parsing, or auditing

It relates to the following issue #s:
* Fixes #52 

cc @bhamail / @DarthHater
