### PR TITLE
Allow comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,14 @@ If you would like to define the path to the file you can use the following
 * `./nancy -exclude-vulnerability-file=/path/to/your/exclude-file /path/to/your/Gopkg.lock`
 * `./nancy -exclude-vulnerability-file=/path/to/your/exclude-file /path/to/your/go.sum`  
 
-The file format requires each vulnerability that you want to exclude to be on a separate line. 
+The file format requires each vulnerability that you want to exclude to be on a separate line. Comments are allowed in the file as well to help provide context when needed. See an example file below.
+
+```
+# This vulnerability is coming from package xyz, we are ok with this for now
+CVN-111 
+CVN-123 # Mitigated the risk of this since we only use one method in this package and the affected code doesn't matter
+CVN-543
+``` 
 
 ### Usage in CI
 

--- a/configuration/parse.go
+++ b/configuration/parse.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/sonatype-nexus-community/nancy/types"
 	"os"
+	"regexp"
 	"strings"
 )
 
@@ -18,6 +19,8 @@ type Configuration struct {
 	CveList types.CveListFlag
 	Path    string
 }
+
+var unixComments = regexp.MustCompile(`#.*$`)
 
 func Parse(args []string) (Configuration, error) {
 	config := Configuration{}
@@ -78,7 +81,10 @@ func getCVEExcludesFromFile(config *Configuration, excludeVulnerabilityFilePath 
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
+		line := scanner.Text()
+		line = unixComments.ReplaceAllString(line, "")
+		line = strings.TrimSpace(line)
+
 		if len(line) > 0 {
 			config.CveList.Cves = append(config.CveList.Cves, line)
 		}

--- a/configuration/parse_test.go
+++ b/configuration/parse_test.go
@@ -15,6 +15,12 @@ func TestConfigParse(t *testing.T) {
 	file := setupCVEExcludeFile(t, "CVF-000\nCVF-123\nCVF-9999")
 	emptyFile := setupCVEExcludeFile(t, "")
 	lotsOfRandomNewlinesFile := setupCVEExcludeFile(t, "\n\nCVN-111\n\n\nCVN-123\nCVN-543\n\n")
+	commentedFile := setupCVEExcludeFile(t, `
+# Comment about this one
+CVN-111 
+CVN-123 #and maybe we put it here too
+# or here
+CVN-543`)
 	dir, _ := ioutil.TempDir("", "prefix")
 
 	defer os.Remove(file.Name())
@@ -43,6 +49,7 @@ func TestConfigParse(t *testing.T) {
 		"exclude vulnerabilities file not found doesn't matter":                      {args: []string{"-exclude-vulnerability-file=/blah-blah-doesnt-exists", "/tmp/go11.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{}, Path: "/tmp/go11.sum"}, expectedErr: nil},
 		"exclude vulnerabilities passed as directory doesn't matter":                 {args: []string{"-exclude-vulnerability-file=" + dir, "/tmp/go12.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{}, Path: "/tmp/go12.sum"}, expectedErr: nil},
 		"exclude vulnerabilities doesn't need to be passed if default value is used": {args: []string{"/tmp/go13.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{Cves: []string{"DEF-111", "DEF-222"}}, Path: "/tmp/go13.sum"}, expectedErr: nil},
+		"exclude vulnerabilities when has comments":                                  {args: []string{"-exclude-vulnerability-file=" + commentedFile.Name(), "/tmp/go14.sum"}, expectedConfig: Configuration{CveList: types.CveListFlag{Cves: []string{"CVN-111", "CVN-123", "CVN-543"}}, Path: "/tmp/go14.sum"}, expectedErr: nil},
 	}
 
 	for name, test := range tests {

--- a/configuration/parse_test.go
+++ b/configuration/parse_test.go
@@ -12,9 +12,21 @@ import (
 )
 
 func TestConfigParse(t *testing.T) {
-	file := setupCVEExcludeFile(t, "CVF-000\nCVF-123\nCVF-9999")
+	file := setupCVEExcludeFile(t, `CVF-000
+CVF-123
+CVF-9999`)
 	emptyFile := setupCVEExcludeFile(t, "")
-	lotsOfRandomNewlinesFile := setupCVEExcludeFile(t, "\n\nCVN-111\n\n\nCVN-123\nCVN-543\n\n")
+	lotsOfRandomNewlinesFile := setupCVEExcludeFile(t, `
+
+
+CVN-111
+
+
+
+
+CVN-123
+CVN-543
+`)
 	commentedFile := setupCVEExcludeFile(t, `
 # Comment about this one
 CVN-111 


### PR DESCRIPTION
Allows comments in the nancy ignore file. I went the easy route and just went with looking for and striping out anything that starts with `#`

It relates to the following issue #s:
* Fixes #51 

cc @bhamail / @DarthHater / @fitzoh 
