### PR TITLE
Fix for CGO_ENABLED=0 some times not working on release artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
   - go mod download
 script:
   - go test ./... -v
+  - go env
   - GOOS=linux GOARCH=amd64 go build -ldflags="-X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildVersion=$VERSION' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildTime=$time' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildCommit=$TRAVIS_COMMIT'" -o nancy-linux.amd64-$VERSION
   - GOOS=darwin GOARCH=amd64 go build -ldflags="-X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildVersion=$VERSION' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildTime=$time' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildCommit=$TRAVIS_COMMIT'" -o nancy-darwin.amd64-$VERSION
   - GOOS=windows GOARCH=amd64 go build -ldflags="-X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildVersion=$VERSION' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildTime=$time' -X 'github.com/sonatype-nexus-community/nancy/buildversion.BuildCommit=$TRAVIS_COMMIT'" -o nancy-windows.amd64-$VERSION.exe
@@ -16,8 +17,7 @@ script:
   - ./nancy-linux.amd64-$VERSION go.sum
   - go list -m all | ./nancy-linux.amd64-$VERSION
 env:
-  - GO111MODULE=on
-  - CGO_ENABLED=0
+  - GO111MODULE=on CGO_ENABLED=0
 
 before_deploy:
   - export TRAVIS_TAG=$VERSION


### PR DESCRIPTION
Fix CGO_ENABLED=0 artifact some times being release. 

See here
https://docs.travis-ci.com/user/environment-variables/#defining-multiple-variables-per-item

To have these not spin up multiple builds you must define them all on
the same line. When they are multiple builds it is a crapshoot as far as
which one gets released b/c its first one wins and that is not
consistent. See comment in #32 that shows screenshots of why build 33 worked and then build 34 did not work.

It relates to the following issue #s:
* Fixes #32

@bhamail / @DarthHater 