### PR TITLE
Make sure dep gives us a Lock struct back

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -96,7 +97,10 @@ func doCheckExistenceAndParse() {
 		}
 		project, err := ctx.LoadProject()
 		if err != nil {
-			customerrors.Check(err, fmt.Sprint("could not read lock at path "+config.Path))
+			customerrors.Check(err, fmt.Sprint("could not read lock at path " + config.Path))
+		}
+		if project.Lock == nil {
+			customerrors.Check(errors.New("dep failed to parse lock file and returned nil"), "nancy could not continue due to dep failure")
 		}
 
 		purls, invalidPurls := packages.ExtractPurlsUsingDep(*project)


### PR DESCRIPTION
Fixes #58. Since dep does not report back an error and gives a valid
Project struct without a Lock instance we must check to make sure its
there before we continue.

cc @bhamail / @DarthHater / @flimzy
