### PR TITLE
audit: newline to seperate vulnerable dependency

### DIFF
--- a/audit/auditlog.go
+++ b/audit/auditlog.go
@@ -55,7 +55,7 @@ func logVulnerablePackage(noColor bool, idx int, packageCount int, coordinate ty
 
 	for j := 0; j < len(coordinate.Vulnerabilities); j++ {
 		if !coordinate.Vulnerabilities[j].Excluded {
-			fmt.Printf("\n%s\n%s\n\nID:%s\nDetails:%s",
+			fmt.Printf("\n%s\n%s\n\nID:%s\nDetails:%s\n",
 				coordinate.Vulnerabilities[j].Title,
 				coordinate.Vulnerabilities[j].Description,
 				coordinate.Vulnerabilities[j].Id,


### PR DESCRIPTION
Add a newline when a vulnerable change is printed. Look for the following lines smushed together.

```
05be37d02b682020/01/21 14:43:31 [135/203] pkg:golang/github.com/opentracing/opentracing-go@1.0.2
```

<details>
<summary>Before</summary>

```
2020/01/21 14:43:31 [133/203] pkg:golang/github.com/opencontainers/image-spec@1.0.1    No known vulnerabilities against package/version
------------------------------------------------------------
[134/203] pkg:golang/github.com/opencontainers/runc@1.0.0-rc9  [Vulnerable]    1 known vulnerabilities affecting installed version

[CVE-2019-5736]  Containment Errors (Container Errors)
runc through 1.0-rc6, as used in Docker before 18.09.2 and other products, allows attackers to overwrite the host runc binary (and consequently obtain host root access) by leveraging the ability to execute a command as root within one of these types of containers: (1) a new container with an attacker-controlled image, or (2) an existing container, to which the attacker previously had write access, that can be attached with docker exec. This occurs because of file-descriptor mishandling, related to /proc/self/exe.

ID:d089f726-f419-4e72-ab60-05be37d02b68
Details:https://ossindex.sonatype.org/vuln/d089f726-f419-4e72-ab60-05be37d02b682020/01/21 14:43:31 [135/203] pkg:golang/github.com/opentracing/opentracing-go@1.0.2    No known vulnerabilities against package/version
2020/01/21 14:43:31 [136/203] pkg:golang/github.com/openzipkin/zipkin-go@0.1.6    No known vulnerabilities against package/version

```

</details>

<details>
<summary>After</summary>

```
2020/01/21 14:48:08 [133/203] pkg:golang/github.com/opencontainers/image-spec@1.0.1    No known vulnerabilities against package/version
------------------------------------------------------------
[134/203] pkg:golang/github.com/opencontainers/runc@1.0.0-rc9  [Vulnerable]    1 known vulnerabilities affecting installed version

[CVE-2019-5736]  Containment Errors (Container Errors)
runc through 1.0-rc6, as used in Docker before 18.09.2 and other products, allows attackers to overwrite the host runc binary (and consequently obtain host root access) by leveraging the ability to execute a command as root within one of these types of containers: (1) a new container with an attacker-controlled image, or (2) an existing container, to which the attacker previously had write access, that can be attached with docker exec. This occurs because of file-descriptor mishandling, related to /proc/self/exe.

ID:d089f726-f419-4e72-ab60-05be37d02b68
Details:https://ossindex.sonatype.org/vuln/d089f726-f419-4e72-ab60-05be37d02b68
2020/01/21 14:48:08 [135/203] pkg:golang/github.com/opentracing/opentracing-go@1.0.2    No known vulnerabilities against package/version
2020/01/21 14:48:08 [136/203] pkg:golang/github.com/openzipkin/zipkin-go@0.1.6    No known vulnerabilities against package/version
```

</details>

cc @bhamail / @DarthHater
