### PR TITLE
Beef up user agent string

### DIFF
--- a/iq/iq.go
+++ b/iq/iq.go
@@ -23,12 +23,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/sonatype-nexus-community/nancy/buildversion"
 	"github.com/sonatype-nexus-community/nancy/configuration"
 	"github.com/sonatype-nexus-community/nancy/customerrors"
 	"github.com/sonatype-nexus-community/nancy/cyclonedx"
 	"github.com/sonatype-nexus-community/nancy/ossindex"
 	"github.com/sonatype-nexus-community/nancy/types"
+	"github.com/sonatype-nexus-community/nancy/useragent"
 )
 
 const internalApplicationIDURL = "/api/v2/applications?publicId="
@@ -114,6 +114,7 @@ func getInternalApplicationID(applicationID string) (internalID string) {
 	)
 
 	req.SetBasicAuth(localConfig.User, localConfig.Token)
+	req.Header.Set("User-Agent", useragent.GetUserAgent())
 
 	resp, err := client.Do(req)
 	customerrors.Check(err, "There was an error communicating with Nexus IQ Server to get your internal application ID")
@@ -143,9 +144,8 @@ func submitToThirdPartyAPI(sbom string, internalID string) string {
 	)
 
 	req.SetBasicAuth(localConfig.User, localConfig.Token)
-
+	req.Header.Set("User-Agent", useragent.GetUserAgent())
 	req.Header.Set("Content-Type", "application/xml")
-	req.Header.Set("User-Agent", fmt.Sprintf("nancy-client/%s", buildversion.BuildVersion))
 
 	resp, err := client.Do(req)
 	customerrors.Check(err, "There was an issue communicating with the Nexus IQ Third Party API")
@@ -174,7 +174,7 @@ func pollIQServer(statusURL string, finished chan bool, maxRetries int) {
 
 	req.SetBasicAuth(localConfig.User, localConfig.Token)
 
-	req.Header.Set("User-Agent", fmt.Sprintf("nancy-client/%s", buildversion.BuildVersion))
+	req.Header.Set("User-Agent", useragent.GetUserAgent())
 
 	resp, err := client.Do(req)
 

--- a/ossindex/ossindex.go
+++ b/ossindex/ossindex.go
@@ -133,9 +133,7 @@ func AuditPackages(purls []string) ([]types.Coordinate, error) {
 				return nil, err
 			}
 
-			if resp.StatusCode == http.StatusOK {
-				log.Printf("Response: %+v\n", resp)
-			} else {
+			if resp.StatusCode != http.StatusOK {
 				return nil, fmt.Errorf("[%s] error accessing OSS Index", resp.Status)
 			}
 

--- a/ossindex/ossindex.go
+++ b/ossindex/ossindex.go
@@ -29,9 +29,9 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger"
-	"github.com/sonatype-nexus-community/nancy/buildversion"
 	"github.com/sonatype-nexus-community/nancy/customerrors"
 	"github.com/sonatype-nexus-community/nancy/types"
+	"github.com/sonatype-nexus-community/nancy/useragent"
 )
 
 const dbValueDirName = "golang"
@@ -205,7 +205,7 @@ func setupRequest(jsonStr []byte) (req *http.Request, err error) {
 		return nil, err
 	}
 
-	req.Header.Set("User-Agent", fmt.Sprintf("nancy-client/%s", buildversion.BuildVersion))
+	req.Header.Set("User-Agent", useragent.GetUserAgent())
 	req.Header.Set("Content-Type", "application/json")
 
 	return req, nil

--- a/ossindex/ossindex_test.go
+++ b/ossindex/ossindex_test.go
@@ -253,7 +253,6 @@ func TestSetupRequest(t *testing.T) {
 	coordJson, _ := setupJson(t)
 	req, err := setupRequest(coordJson)
 
-	assert.Equal(t, req.Header.Get("User-Agent"), "nancy-client/development")
 	assert.Equal(t, req.Header.Get("Content-Type"), "application/json")
 	assert.Equal(t, req.Method, "POST")
 	assert.Nil(t, err)

--- a/useragent/useragent.go
+++ b/useragent/useragent.go
@@ -1,3 +1,18 @@
+// Copyright 2020 Sonatype Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package useragent has functions for setting a user agent with helpful information
 package useragent
 
 import (
@@ -8,27 +23,51 @@ import (
 	"github.com/sonatype-nexus-community/nancy/buildversion"
 )
 
+var GOOS = runtime.GOOS
+var GOARCH = runtime.GOARCH
+
 func GetUserAgent() (useragent string) {
 	useragent = fmt.Sprintf("nancy-client/%s", buildversion.BuildVersion)
 	if checkForCIEnvironment() {
 		callerInfo := getCallerInfo()
-		if callerInfo == "" && checkForCircleCI() {
-			useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "circleci", runtime.GOOS, runtime.GOARCH)
+		if callerInfo == "" {
+			useragent = checkCIEnvironments(useragent)
+			return
 		}
-		if callerInfo == "" && checkForBitBucket() {
-			useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "bitbucket", runtime.GOOS, runtime.GOARCH)
-		} else {
-			useragent = useragent + fmt.Sprintf(" (%s; %s %s)", callerInfo, runtime.GOOS, runtime.GOARCH)
-		}
-	} else {
-		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "non ci usage", runtime.GOOS, runtime.GOARCH)
+		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", callerInfo, GOOS, runtime.GOARCH)
+		return
 	}
+	useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "non ci usage", GOOS, runtime.GOARCH)
 
 	return
 }
 
+func checkCIEnvironments(useragent string) string {
+	if checkForCISystem("CIRCLECI") {
+		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "circleci", GOOS, runtime.GOARCH)
+	}
+	if checkForCISystem("BITBUCKET_BUILD_NUMBER") {
+		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "bitbucket", GOOS, runtime.GOARCH)
+	}
+	if checkForCISystem("TRAVIS") {
+		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "travis-ci", GOOS, runtime.GOARCH)
+	}
+	if checkIfJenkins() {
+		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "jenkins", GOOS, runtime.GOARCH)
+	}
+	return useragent
+}
+
 func checkForCIEnvironment() bool {
 	s := os.Getenv("CI")
+	if s != "" {
+		return true
+	}
+	return checkIfJenkins()
+}
+
+func checkIfJenkins() bool {
+	s := os.Getenv("JENKINS_HOME")
 	if s != "" {
 		return true
 	}
@@ -38,22 +77,11 @@ func checkForCIEnvironment() bool {
 // Returns info from SC_CALLER_INFO, example: bitbucket-nancy-pipe-0.1.9
 func getCallerInfo() string {
 	s := os.Getenv("SC_CALLER_INFO")
-	if s != "" {
-		return s
-	}
-	return ""
+	return s
 }
 
-func checkForCircleCI() bool {
-	s := os.Getenv("CIRCLECI")
-	if s != "" {
-		return true
-	}
-	return false
-}
-
-func checkForBitBucket() bool {
-	s := os.Getenv("BITBUCKET_BUILD_NUMBER")
+func checkForCISystem(system string) bool {
+	s := os.Getenv(system)
 	if s != "" {
 		return true
 	}

--- a/useragent/useragent.go
+++ b/useragent/useragent.go
@@ -23,9 +23,18 @@ import (
 	"github.com/sonatype-nexus-community/nancy/buildversion"
 )
 
-var GOOS = runtime.GOOS
-var GOARCH = runtime.GOARCH
+// Variables that can be overriden (primarily for tests), or for consumers
+var (
+	GOOS       = runtime.GOOS
+	GOARCH     = runtime.GOARCH
+	CLIENTTOOL = "nancy-client"
+)
 
+// GetUserAgent provides a user-agent to nancy that provides info on what version of nancy
+// (or upstream consumers like ahab or cheque) is running, and if the process is being run in
+// CI. If so, it looks for what CI system, and other information such as SC_CALLER_INFO which
+// can be used to tell if nancy is being ran inside an orb, bitbucket pipeline, etc... that
+// we authored
 func GetUserAgent() string {
 	if checkForCIEnvironment() {
 		callerInfo := getCallerInfo()
@@ -38,7 +47,7 @@ func GetUserAgent() string {
 }
 
 func getUserAgentBaseAndVersion() string {
-	return fmt.Sprintf("nancy-client/%s", buildversion.BuildVersion)
+	return fmt.Sprintf("%s/%s", CLIENTTOOL, buildversion.BuildVersion)
 }
 
 func checkCIEnvironments() string {

--- a/useragent/useragent.go
+++ b/useragent/useragent.go
@@ -1,0 +1,61 @@
+package useragent
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/sonatype-nexus-community/nancy/buildversion"
+)
+
+func GetUserAgent() (useragent string) {
+	useragent = fmt.Sprintf("nancy-client/%s", buildversion.BuildVersion)
+	if checkForCIEnvironment() {
+		callerInfo := getCallerInfo()
+		if callerInfo == "" && checkForCircleCI() {
+			useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "circleci", runtime.GOOS, runtime.GOARCH)
+		}
+		if callerInfo == "" && checkForBitBucket() {
+			useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "bitbucket", runtime.GOOS, runtime.GOARCH)
+		} else {
+			useragent = useragent + fmt.Sprintf(" (%s; %s %s)", callerInfo, runtime.GOOS, runtime.GOARCH)
+		}
+	} else {
+		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "non ci usage", runtime.GOOS, runtime.GOARCH)
+	}
+
+	return
+}
+
+func checkForCIEnvironment() bool {
+	s := os.Getenv("CI")
+	if s != "" {
+		return true
+	}
+	return false
+}
+
+// Returns info from SC_CALLER_INFO, example: bitbucket-nancy-pipe-0.1.9
+func getCallerInfo() string {
+	s := os.Getenv("SC_CALLER_INFO")
+	if s != "" {
+		return s
+	}
+	return ""
+}
+
+func checkForCircleCI() bool {
+	s := os.Getenv("CIRCLECI")
+	if s != "" {
+		return true
+	}
+	return false
+}
+
+func checkForBitBucket() bool {
+	s := os.Getenv("BITBUCKET_BUILD_NUMBER")
+	if s != "" {
+		return true
+	}
+	return false
+}

--- a/useragent/useragent.go
+++ b/useragent/useragent.go
@@ -36,46 +36,43 @@ var (
 // can be used to tell if nancy is being ran inside an orb, bitbucket pipeline, etc... that
 // we authored
 func GetUserAgent() string {
+	callTree := os.Getenv("SC_CALLER_INFO")
 	if checkForCIEnvironment() {
-		callerInfo := getCallerInfo()
-		if callerInfo == "" {
-			return checkCIEnvironments()
-		}
-		return getCIBasedUserAgent(callerInfo)
+		return checkCIEnvironments(callTree)
 	}
-	return getCIBasedUserAgent("non ci usage")
+	return getUserAgent("non ci usage", callTree)
 }
 
 func getUserAgentBaseAndVersion() string {
 	return fmt.Sprintf("%s/%s", CLIENTTOOL, buildversion.BuildVersion)
 }
 
-func checkCIEnvironments() string {
+func checkCIEnvironments(callTree string) string {
 	if checkForCISystem("CIRCLECI") {
-		return getCIBasedUserAgent("circleci")
+		return getUserAgent("circleci", callTree)
 	}
 	if checkForCISystem("BITBUCKET_BUILD_NUMBER") {
-		return getCIBasedUserAgent("bitbucket")
+		return getUserAgent("bitbucket", callTree)
 	}
 	if checkForCISystem("TRAVIS") {
-		return getCIBasedUserAgent("travis-ci")
+		return getUserAgent("travis-ci", callTree)
 	}
 	if checkForCISystem("GITLAB_CI") {
-		return getCIBasedUserAgent("gitlab-ci")
+		return getUserAgent("gitlab-ci", callTree)
 	}
 	if checkIfJenkins() {
-		return getCIBasedUserAgent("jenkins")
+		return getUserAgent("jenkins", callTree)
 	}
 	if checkIfGitHub() {
 		id := getGitHubActionID()
-		return getCIBasedUserAgent(fmt.Sprintf("github-action %s", id))
+		return getUserAgent(fmt.Sprintf("github-action %s", id), callTree)
 	}
 
-	return getCIBasedUserAgent("ci usage")
+	return getUserAgent("ci usage", callTree)
 }
 
-func getCIBasedUserAgent(agent string) string {
-	return fmt.Sprintf("%s (%s; %s %s)", getUserAgentBaseAndVersion(), agent, GOOS, GOARCH)
+func getUserAgent(agent string, callTree string) string {
+	return fmt.Sprintf("%s (%s; %s %s; %s)", getUserAgentBaseAndVersion(), agent, GOOS, GOARCH, callTree)
 }
 
 func checkForCIEnvironment() bool {

--- a/useragent/useragent.go
+++ b/useragent/useragent.go
@@ -34,26 +34,30 @@ func GetUserAgent() (useragent string) {
 			useragent = checkCIEnvironments(useragent)
 			return
 		}
-		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", callerInfo, GOOS, runtime.GOARCH)
+		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", callerInfo, GOOS, GOARCH)
 		return
 	}
-	useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "non ci usage", GOOS, runtime.GOARCH)
+	useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "non ci usage", GOOS, GOARCH)
 
 	return
 }
 
 func checkCIEnvironments(useragent string) string {
 	if checkForCISystem("CIRCLECI") {
-		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "circleci", GOOS, runtime.GOARCH)
+		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "circleci", GOOS, GOARCH)
 	}
 	if checkForCISystem("BITBUCKET_BUILD_NUMBER") {
-		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "bitbucket", GOOS, runtime.GOARCH)
+		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "bitbucket", GOOS, GOARCH)
 	}
 	if checkForCISystem("TRAVIS") {
-		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "travis-ci", GOOS, runtime.GOARCH)
+		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "travis-ci", GOOS, GOARCH)
 	}
 	if checkIfJenkins() {
-		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "jenkins", GOOS, runtime.GOARCH)
+		useragent = useragent + fmt.Sprintf(" (%s; %s %s)", "jenkins", GOOS, GOARCH)
+	}
+	if checkIfGitHub() {
+		id := getGitHubActionID()
+		useragent = useragent + fmt.Sprintf(" (%s %s; %s %s)", "github-action", id, GOOS, GOARCH)
 	}
 	return useragent
 }
@@ -63,7 +67,7 @@ func checkForCIEnvironment() bool {
 	if s != "" {
 		return true
 	}
-	return checkIfJenkins()
+	return checkIfJenkins() || checkIfGitHub()
 }
 
 func checkIfJenkins() bool {
@@ -74,9 +78,22 @@ func checkIfJenkins() bool {
 	return false
 }
 
+func checkIfGitHub() bool {
+	s := os.Getenv("GITHUB_ACTIONS")
+	if s != "" {
+		return true
+	}
+	return false
+}
+
 // Returns info from SC_CALLER_INFO, example: bitbucket-nancy-pipe-0.1.9
 func getCallerInfo() string {
 	s := os.Getenv("SC_CALLER_INFO")
+	return s
+}
+
+func getGitHubActionID() string {
+	s := os.Getenv("GITHUB_ACTION")
 	return s
 }
 

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -59,6 +59,8 @@ func TestGetUserAgentJenkins(t *testing.T) {
 
 	agent := GetUserAgent()
 
+	os.Unsetenv("JENKINS_HOME")
+
 	if agent != expected {
 		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)
 	}
@@ -74,6 +76,9 @@ func TestGetUserAgentTravisCI(t *testing.T) {
 	GOARCH = "amd64"
 
 	agent := GetUserAgent()
+
+	os.Unsetenv("CI")
+	os.Unsetenv("TRAVIS")
 
 	if agent != expected {
 		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)
@@ -91,6 +96,9 @@ func TestGetUserAgentBitBucket(t *testing.T) {
 
 	agent := GetUserAgent()
 
+	os.Unsetenv("CI")
+	os.Unsetenv("BITBUCKET_BUILD_NUMBER")
+
 	if agent != expected {
 		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)
 	}
@@ -106,6 +114,9 @@ func TestGetUserAgentScCallerInfo(t *testing.T) {
 	GOARCH = "amd64"
 
 	agent := GetUserAgent()
+
+	os.Unsetenv("CI")
+	os.Unsetenv("SC_CALLER_INFO")
 
 	if agent != expected {
 		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestGetUserAgentNonCI(t *testing.T) {
 	clearCircleCIVariables()
-	expected := "nancy-client/development (non ci usage; linux amd64)"
+	expected := "nancy-client/development (non ci usage; linux amd64; )"
 
 	GOOS = "linux"
 	GOARCH = "amd64"
@@ -35,7 +35,7 @@ func TestGetUserAgentNonCI(t *testing.T) {
 }
 
 func TestGetUserAgentCircleCI(t *testing.T) {
-	expected := "nancy-client/development (circleci; linux amd64)"
+	expected := "nancy-client/development (circleci; linux amd64; )"
 
 	os.Setenv("CI", "true")
 	os.Setenv("CIRCLECI", "true")
@@ -51,7 +51,7 @@ func TestGetUserAgentCircleCI(t *testing.T) {
 
 func TestGetUserAgentJenkins(t *testing.T) {
 	clearCircleCIVariables()
-	expected := "nancy-client/development (jenkins; linux amd64)"
+	expected := "nancy-client/development (jenkins; linux amd64; )"
 
 	os.Setenv("JENKINS_HOME", "/a/place/under/the/sun")
 	GOOS = "linux"
@@ -68,7 +68,7 @@ func TestGetUserAgentJenkins(t *testing.T) {
 
 func TestGetUserAgentTravisCI(t *testing.T) {
 	clearCircleCIVariables()
-	expected := "nancy-client/development (travis-ci; linux amd64)"
+	expected := "nancy-client/development (travis-ci; linux amd64; )"
 
 	os.Setenv("CI", "true")
 	os.Setenv("TRAVIS", "true")
@@ -87,7 +87,7 @@ func TestGetUserAgentTravisCI(t *testing.T) {
 
 func TestGetUserAgentGitLabCI(t *testing.T) {
 	clearCircleCIVariables()
-	expected := "nancy-client/development (gitlab-ci; linux amd64)"
+	expected := "nancy-client/development (gitlab-ci; linux amd64; )"
 
 	os.Setenv("CI", "true")
 	os.Setenv("GITLAB_CI", "true")
@@ -106,7 +106,7 @@ func TestGetUserAgentGitLabCI(t *testing.T) {
 
 func TestGetUserAgentGitHubAction(t *testing.T) {
 	clearCircleCIVariables()
-	expected := "nancy-client/development (github-action 20; linux amd64)"
+	expected := "nancy-client/development (github-action 20; linux amd64; )"
 
 	os.Setenv("GITHUB_ACTIONS", "true")
 	os.Setenv("GITHUB_ACTION", "20")
@@ -125,7 +125,7 @@ func TestGetUserAgentGitHubAction(t *testing.T) {
 
 func TestGetUserAgentBitBucket(t *testing.T) {
 	clearCircleCIVariables()
-	expected := "nancy-client/development (bitbucket; linux amd64)"
+	expected := "nancy-client/development (bitbucket; linux amd64; )"
 
 	os.Setenv("CI", "true")
 	os.Setenv("BITBUCKET_BUILD_NUMBER", "20")
@@ -144,16 +144,14 @@ func TestGetUserAgentBitBucket(t *testing.T) {
 
 func TestGetUserAgentScCallerInfo(t *testing.T) {
 	clearCircleCIVariables()
-	expected := "nancy-client/development (bitbucket-nancy-pipe-0.1.9; linux amd64)"
+	expected := "nancy-client/development (non ci usage; linux amd64; bitbucket-nancy-pipe-0.1.9)"
 
-	os.Setenv("CI", "true")
 	os.Setenv("SC_CALLER_INFO", "bitbucket-nancy-pipe-0.1.9")
 	GOOS = "linux"
 	GOARCH = "amd64"
 
 	agent := GetUserAgent()
 
-	os.Unsetenv("CI")
 	os.Unsetenv("SC_CALLER_INFO")
 
 	if agent != expected {
@@ -163,7 +161,7 @@ func TestGetUserAgentScCallerInfo(t *testing.T) {
 
 func TestGetUserAgentCINoClueWhatSystem(t *testing.T) {
 	clearCircleCIVariables()
-	expected := "nancy-client/development (ci usage; linux amd64)"
+	expected := "nancy-client/development (ci usage; linux amd64; )"
 
 	os.Setenv("CI", "true")
 	GOOS = "linux"

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -85,6 +85,25 @@ func TestGetUserAgentTravisCI(t *testing.T) {
 	}
 }
 
+func TestGetUserAgentGitHubAction(t *testing.T) {
+	clearCircleCIVariables()
+	expected := "nancy-client/development (github-action 20; linux amd64)"
+
+	os.Setenv("GITHUB_ACTIONS", "true")
+	os.Setenv("GITHUB_ACTION", "20")
+	GOOS = "linux"
+	GOARCH = "amd64"
+
+	agent := GetUserAgent()
+
+	os.Unsetenv("GITHUB_ACTIONS")
+	os.Unsetenv("GITHUB_ACTION")
+
+	if agent != expected {
+		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)
+	}
+}
+
 func TestGetUserAgentBitBucket(t *testing.T) {
 	clearCircleCIVariables()
 	expected := "nancy-client/development (bitbucket; linux amd64)"

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -85,6 +85,25 @@ func TestGetUserAgentTravisCI(t *testing.T) {
 	}
 }
 
+func TestGetUserAgentGitLabCI(t *testing.T) {
+	clearCircleCIVariables()
+	expected := "nancy-client/development (gitlab-ci; linux amd64)"
+
+	os.Setenv("CI", "true")
+	os.Setenv("GITLAB_CI", "true")
+	GOOS = "linux"
+	GOARCH = "amd64"
+
+	agent := GetUserAgent()
+
+	os.Unsetenv("CI")
+	os.Unsetenv("GITLAB_CI")
+
+	if agent != expected {
+		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)
+	}
+}
+
 func TestGetUserAgentGitHubAction(t *testing.T) {
 	clearCircleCIVariables()
 	expected := "nancy-client/development (github-action 20; linux amd64)"
@@ -136,6 +155,23 @@ func TestGetUserAgentScCallerInfo(t *testing.T) {
 
 	os.Unsetenv("CI")
 	os.Unsetenv("SC_CALLER_INFO")
+
+	if agent != expected {
+		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)
+	}
+}
+
+func TestGetUserAgentCINoClueWhatSystem(t *testing.T) {
+	clearCircleCIVariables()
+	expected := "nancy-client/development (ci usage; linux amd64)"
+
+	os.Setenv("CI", "true")
+	GOOS = "linux"
+	GOARCH = "amd64"
+
+	agent := GetUserAgent()
+
+	os.Unsetenv("CI")
 
 	if agent != expected {
 		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestGetUserAgentNonCI(t *testing.T) {
+	clearCircleCIVariables()
 	expected := "nancy-client/development (non ci usage; linux amd64)"
 
 	GOOS = "linux"
@@ -112,5 +113,6 @@ func TestGetUserAgentScCallerInfo(t *testing.T) {
 }
 
 func clearCircleCIVariables() {
+	os.Unsetenv("CI")
 	os.Unsetenv("CIRCLECI")
 }

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -49,6 +49,7 @@ func TestGetUserAgentCircleCI(t *testing.T) {
 }
 
 func TestGetUserAgentJenkins(t *testing.T) {
+	clearCircleCIVariables()
 	expected := "nancy-client/development (jenkins; linux amd64)"
 
 	os.Setenv("JENKINS_HOME", "/a/place/under/the/sun")
@@ -63,6 +64,7 @@ func TestGetUserAgentJenkins(t *testing.T) {
 }
 
 func TestGetUserAgentTravisCI(t *testing.T) {
+	clearCircleCIVariables()
 	expected := "nancy-client/development (travis-ci; linux amd64)"
 
 	os.Setenv("CI", "true")
@@ -78,6 +80,7 @@ func TestGetUserAgentTravisCI(t *testing.T) {
 }
 
 func TestGetUserAgentBitBucket(t *testing.T) {
+	clearCircleCIVariables()
 	expected := "nancy-client/development (bitbucket; linux amd64)"
 
 	os.Setenv("CI", "true")
@@ -93,6 +96,7 @@ func TestGetUserAgentBitBucket(t *testing.T) {
 }
 
 func TestGetUserAgentScCallerInfo(t *testing.T) {
+	clearCircleCIVariables()
 	expected := "nancy-client/development (bitbucket-nancy-pipe-0.1.9; linux amd64)"
 
 	os.Setenv("CI", "true")
@@ -105,4 +109,8 @@ func TestGetUserAgentScCallerInfo(t *testing.T) {
 	if agent != expected {
 		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)
 	}
+}
+
+func clearCircleCIVariables() {
+	os.Unsetenv("CIRCLECI")
 }

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -1,11 +1,107 @@
+// Copyright 2020 Sonatype Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package useragent has functions for setting a user agent with helpful information
 package useragent
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
-func TestGetUserAgent(t *testing.T) {
+func TestGetUserAgentNonCI(t *testing.T) {
+	expected := "nancy-client/development (non ci usage; linux amd64)"
+
+	GOOS = "linux"
+	GOARCH = "amd64"
+
 	agent := GetUserAgent()
 
-	expected := "nancy-client/build"
+	if agent != expected {
+		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)
+	}
+}
+
+func TestGetUserAgentCircleCI(t *testing.T) {
+	expected := "nancy-client/development (circleci; linux amd64)"
+
+	os.Setenv("CI", "true")
+	os.Setenv("CIRCLECI", "true")
+	GOOS = "linux"
+	GOARCH = "amd64"
+
+	agent := GetUserAgent()
+
+	if agent != expected {
+		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)
+	}
+}
+
+func TestGetUserAgentJenkins(t *testing.T) {
+	expected := "nancy-client/development (jenkins; linux amd64)"
+
+	os.Setenv("JENKINS_HOME", "/a/place/under/the/sun")
+	GOOS = "linux"
+	GOARCH = "amd64"
+
+	agent := GetUserAgent()
+
+	if agent != expected {
+		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)
+	}
+}
+
+func TestGetUserAgentTravisCI(t *testing.T) {
+	expected := "nancy-client/development (travis-ci; linux amd64)"
+
+	os.Setenv("CI", "true")
+	os.Setenv("TRAVIS", "true")
+	GOOS = "linux"
+	GOARCH = "amd64"
+
+	agent := GetUserAgent()
+
+	if agent != expected {
+		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)
+	}
+}
+
+func TestGetUserAgentBitBucket(t *testing.T) {
+	expected := "nancy-client/development (bitbucket; linux amd64)"
+
+	os.Setenv("CI", "true")
+	os.Setenv("BITBUCKET_BUILD_NUMBER", "20")
+	GOOS = "linux"
+	GOARCH = "amd64"
+
+	agent := GetUserAgent()
+
+	if agent != expected {
+		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)
+	}
+}
+
+func TestGetUserAgentScCallerInfo(t *testing.T) {
+	expected := "nancy-client/development (bitbucket-nancy-pipe-0.1.9; linux amd64)"
+
+	os.Setenv("CI", "true")
+	os.Setenv("SC_CALLER_INFO", "bitbucket-nancy-pipe-0.1.9")
+	GOOS = "linux"
+	GOARCH = "amd64"
+
+	agent := GetUserAgent()
+
 	if agent != expected {
 		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)
 	}

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -1,0 +1,12 @@
+package useragent
+
+import "testing"
+
+func TestGetUserAgent(t *testing.T) {
+	agent := GetUserAgent()
+
+	expected := "nancy-client/build"
+	if agent != expected {
+		t.Errorf("User Agent not retrieved successfully, got %s, expected %s", agent, expected)
+	}
+}


### PR DESCRIPTION
Basically, we send in a user-agent string, but it was really "simple". Let's add a couple bits more info:

- If Nancy is being run in CI, let's say what system it's being run in
- If Nancy is being run in CI, in a orb, etc... that we create, add the info that the orb supplies `SC_CALLER_INFO` environment variable is our new friend (hi @bhamail )
- Regardless of Nancy being run in CI, let's send back the OS and the architecture so we know a bit more about who is doing Golang development with Nancy

What is the goal here? Well, not to be creepy, that's for sure. It's to get some information that we can use to help prioritize new work, like building more orbs, working on new orbs, etc...

This pull request makes the following changes:
* Adds a new package `useragent`
* Logic for finding out what CI system is being run, and providing additional information if it exists
* TESTS

cc @bhamail / @DarthHater / @zendern / @greut / @fitzoh 
