### PR TITLE
Squelch Header (including version) if formatter is other than text, or if we say to be quiet!

### DIFF
--- a/audit/auditlogtextformatter.go
+++ b/audit/auditlogtextformatter.go
@@ -3,11 +3,12 @@ package audit
 import (
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/logrusorgru/aurora"
 	. "github.com/sirupsen/logrus"
 	"github.com/sonatype-nexus-community/nancy/types"
-	"strconv"
-	"strings"
 )
 
 type AuditLogTextFormatter struct {
@@ -77,13 +78,8 @@ func (f *AuditLogTextFormatter) Format(entry *Entry) ([]byte, error) {
 		invalidEntries := entry.Data["invalid"].([]types.Coordinate)
 		packageCount := entry.Data["num_audited"].(int)
 		numVulnerable := entry.Data["num_vulnerable"].(int)
-		buildVersion := entry.Data["version"].(string)
 
 		var sb strings.Builder
-
-		if !*f.Quiet {
-			sb.WriteString("Nancy version: " + buildVersion + "\n")
-		}
 
 		logInvalidSemVerWarning(&sb, *f.NoColor, *f.Quiet, invalidEntries)
 		for idx := 0; idx < len(auditedEntries); idx++ {

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/sonatype-nexus-community/nancy/types"
@@ -56,9 +57,12 @@ func main() {
 	}
 }
 
-func printHeader() {
-	figure.NewFigure("Nancy", "larry3d", true).Print()
-	figure.NewFigure("By Sonatype & Friends", "pepper", true).Print()
+func printHeader(quiet bool) {
+	if quiet {
+		figure.NewFigure("Nancy", "larry3d", true).Print()
+		figure.NewFigure("By Sonatype & Friends", "pepper", true).Print()
+		log.Println("Nancy version: " + buildversion.BuildVersion)
+	}
 }
 
 func processConfig(config configuration.Configuration) {
@@ -86,9 +90,7 @@ func processConfig(config configuration.Configuration) {
 		log.SetOutput(ioutil.Discard)
 	}
 
-	printHeader()
-
-	log.Println("Nancy version: " + buildversion.BuildVersion)
+	printHeader((!config.Quiet && reflect.TypeOf(config.Formatter).String() == "*audit.AuditLogTextFormatter"))
 
 	if config.UseStdIn {
 		doStdInAndParse(config)
@@ -115,9 +117,7 @@ func processIQConfig(config configuration.IqConfiguration) {
 		flag.Usage()
 	}
 
-	printHeader()
-
-	log.Println("Nancy version: " + buildversion.BuildVersion)
+	printHeader(true)
 
 	doStdInAndParseForIQ(config)
 }

--- a/main.go
+++ b/main.go
@@ -57,8 +57,8 @@ func main() {
 	}
 }
 
-func printHeader(quiet bool) {
-	if quiet {
+func printHeader(print bool) {
+	if print {
 		figure.NewFigure("Nancy", "larry3d", true).Print()
 		figure.NewFigure("By Sonatype & Friends", "pepper", true).Print()
 		log.Println("Nancy version: " + buildversion.BuildVersion)


### PR DESCRIPTION
Based on an observation in #90 , basically just print the header in certain cases:

- If the textformatter is `reflect.TypeOf(config.Formatter).String() == "*audit.AuditLogTextFormatter")` (my first time ever using reflection in golang)
- if we are using IQ server
- if someone hasn't said "be quiet", aka `-quiet`

This pull request makes the following changes:
* Some logic changes in `main.go`
* Stripped out version printing in `AuditLogTextFormatter` as that seems to be an overlap with `main.go`

It relates to the following issue #s:
* Fixes #90 

cc @bhamail / @DarthHater / @zendern / @AndreyMZ
