### PR TITLE
Welp, let's let redirection work too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
       - run: cd packages/testdata && ../../nancy Gopkg.lock && cd -
       - run: ./nancy go.sum
       - run: go list -m all | ./nancy
+      - run: go list -m all > deps.out && ./nancy < deps.out
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:

--- a/main.go
+++ b/main.go
@@ -200,7 +200,7 @@ func checkStdIn() {
 	if (stat.Mode() & os.ModeCharDevice) == 0 {
 		LogLady.Info("StdIn is valid")
 	} else {
-		LogLady.Error("StdIn is invalid")
+		LogLady.Error("StdIn is invalid, either empty or another reason")
 		flag.Usage()
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -208,6 +208,7 @@ func checkStdIn() {
 
 func doStdInAndParseForIQ(config configuration.IqConfiguration) {
 	LogLady.Debug("Beginning StdIn parse for IQ")
+	checkStdIn()
 	LogLady.Info("Instantiating go.mod package")
 
 	mod := packages.Mod{}


### PR DESCRIPTION
In #92 we discovered that Nancy would only accept piped stdin, not redirected. This PR aims to fix that!

This pull request makes the following changes:
* Adds a new `checkStdIn()` function to remove some duplicate code
* Maintains same behavior of previous StdIn check, but uses `os.ModeCharDevice` to check if something is in StdIn

It relates to the following issue #s:
* Fixes #92

cc @bhamail / @DarthHater / @zendern / @fitzoh / @AndreyMZ
