### PR TITLE
Check for existence of unmarshalled internal ID before returning

### DIFF
--- a/iq/iq.go
+++ b/iq/iq.go
@@ -142,7 +142,16 @@ func getInternalApplicationID(applicationID string) (internalID string) {
 
 		var response applicationResponse
 		json.Unmarshal(bodyBytes, &response)
-		return response.Applications[0].ID
+		if response.Applications != nil && len(response.Applications) > 0 {
+			LogLady.WithFields(logrus.Fields{
+				"internal_id": response.Applications[0].ID,
+			}).Debug("Retrieved internal ID from Nexus IQ Server")
+
+			return response.Applications[0].ID
+		}
+		LogLady.WithFields(logrus.Fields{
+			"application_id": applicationID,
+		}).Error("Unable to retrieve an internal ID for the specified public application ID")
 	}
 	return ""
 }

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -77,10 +77,10 @@ func AuditPackages(purls []string, applicationID string, config configuration.Iq
 		warnUserOfBadLifeChoices()
 	}
 
-	internalID := getInternalApplicationID(applicationID)
-	if internalID == "" {
+	internalID, err := getInternalApplicationID(applicationID)
+	if internalID == "" && err != nil {
 		LogLady.Error("Internal ID not obtained from Nexus IQ")
-		return statusURLResp, fmt.Errorf("Internal ID for %s could not be found, or Nexus IQ Server is down", applicationID)
+		return statusURLResp, err
 	}
 
 	resultsFromOssIndex, err := ossindex.AuditPackages(purls)
@@ -119,7 +119,7 @@ func AuditPackages(purls []string, applicationID string, config configuration.Iq
 	return statusURLResp, nil
 }
 
-func getInternalApplicationID(applicationID string) (internalID string) {
+func getInternalApplicationID(applicationID string) (string, error) {
 	client := &http.Client{}
 
 	req, err := http.NewRequest(
@@ -142,18 +142,25 @@ func getInternalApplicationID(applicationID string) (internalID string) {
 
 		var response applicationResponse
 		json.Unmarshal(bodyBytes, &response)
+
 		if response.Applications != nil && len(response.Applications) > 0 {
 			LogLady.WithFields(logrus.Fields{
 				"internal_id": response.Applications[0].ID,
 			}).Debug("Retrieved internal ID from Nexus IQ Server")
 
-			return response.Applications[0].ID
+			return response.Applications[0].ID, nil
 		}
+
 		LogLady.WithFields(logrus.Fields{
 			"application_id": applicationID,
 		}).Error("Unable to retrieve an internal ID for the specified public application ID")
+
+		return "", fmt.Errorf("Unable to retrieve an internal ID for the specified public application ID: %s", applicationID)
 	}
-	return ""
+	LogLady.WithFields(logrus.Fields{
+		"status_code": resp.StatusCode,
+	}).Error("Error communicating with Nexus IQ Server application endpoint")
+	return "", fmt.Errorf("Unable to communicate with Nexus IQ Server, status code returned is: %d", resp.StatusCode)
 }
 
 func submitToThirdPartyAPI(sbom string, internalID string) string {

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -104,6 +104,7 @@ func TestAuditPackages(t *testing.T) {
 }
 
 func TestAuditPackagesIqCannotLocateApplicationID(t *testing.T) {
+	expectedError := "Unable to retrieve an internal ID for the specified public application ID: testapp"
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
@@ -116,10 +117,10 @@ func TestAuditPackagesIqCannotLocateApplicationID(t *testing.T) {
 
 	_, err := AuditPackages(purls, "testapp", setupIqConfiguration())
 	if err == nil {
-		t.Error("There is an error")
+		t.Errorf("err should not be nil, expected an err with the following text: %s", expectedError)
 	}
-	if err.Error() != "Internal ID for testapp could not be found, or Nexus IQ Server is down" {
-		t.Error("Error returned is not as expected")
+	if err.Error() != expectedError {
+		t.Errorf("Error returned is not as expected. Expected: %s but got: %s", expectedError, err.Error())
 	}
 }
 


### PR DESCRIPTION
Basically we need to check if the unmarshall was successful, when sending a public application ID to Nexus IQ Server

This pull request makes the following changes:
* Quick logic check before returning
* Add some logging around the check to help someone find the issue later

cc @bhamail / @DarthHater
