### PR TITLE
Initial cleanup of error messages

### DIFF
--- a/configuration/parse.go
+++ b/configuration/parse.go
@@ -121,10 +121,12 @@ func loadConfigFromFile(configLocation string, config *Configuration) error {
 func loadIQConfigFromFile(configLocation string, config *IqConfiguration) error {
 	b, err := ioutil.ReadFile(configLocation)
 	if err != nil {
+		LogLady.WithField("error", err).Error("Unable to read file")
 		return err
 	}
 	err = yaml.Unmarshal(b, config)
 	if err != nil {
+		LogLady.WithField("error", err).Error("Unable to unmarshal file into config")
 		return err
 	}
 

--- a/configuration/parse.go
+++ b/configuration/parse.go
@@ -92,7 +92,6 @@ Options:
 
 	err = loadIQConfigFromFile(ConfigLocation, &config)
 	if err != nil {
-		fmt.Println(err)
 		LogLady.Info("Unable to load config from file")
 	}
 
@@ -174,7 +173,6 @@ Options:
 
 	err := loadConfigFromFile(ConfigLocation, &config)
 	if err != nil {
-		fmt.Println(err)
 		LogLady.Info("Unable to load config from file")
 	}
 

--- a/configuration/parse.go
+++ b/configuration/parse.go
@@ -106,10 +106,12 @@ Options:
 func loadConfigFromFile(configLocation string, config *Configuration) error {
 	b, err := ioutil.ReadFile(configLocation)
 	if err != nil {
+		LogLady.WithField("error", err).Error("Unable to read file")
 		return err
 	}
 	err = yaml.Unmarshal(b, config)
 	if err != nil {
+		LogLady.WithField("error", err).Error("Unable to unmarshal file into config")
 		return err
 	}
 

--- a/configuration/parse.go
+++ b/configuration/parse.go
@@ -106,12 +106,12 @@ Options:
 func loadConfigFromFile(configLocation string, config *Configuration) error {
 	b, err := ioutil.ReadFile(configLocation)
 	if err != nil {
-		LogLady.WithField("error", err).Error("Unable to read file")
+		LogLady.WithField("error", err).Error("Unable to read OSS Index file")
 		return err
 	}
 	err = yaml.Unmarshal(b, config)
 	if err != nil {
-		LogLady.WithField("error", err).Error("Unable to unmarshal file into config")
+		LogLady.WithField("error", err).Error("Unable to unmarshal file into OSS Index config")
 		return err
 	}
 
@@ -121,12 +121,12 @@ func loadConfigFromFile(configLocation string, config *Configuration) error {
 func loadIQConfigFromFile(configLocation string, config *IqConfiguration) error {
 	b, err := ioutil.ReadFile(configLocation)
 	if err != nil {
-		LogLady.WithField("error", err).Error("Unable to read file")
+		LogLady.WithField("error", err).Error("Unable to read IQ file")
 		return err
 	}
 	err = yaml.Unmarshal(b, config)
 	if err != nil {
-		LogLady.WithField("error", err).Error("Unable to unmarshal file into config")
+		LogLady.WithField("error", err).Error("Unable to unmarshal file into IQ config")
 		return err
 	}
 

--- a/customerrors/error.go
+++ b/customerrors/error.go
@@ -36,10 +36,11 @@ func (sw SwError) Exit() {
 
 func Check(err error, message string) {
 	if err != nil {
+		location, _ := LogFileLocation()
 		myErr := SwError{Message: message, Err: err}
 		LogLady.WithField("error", err).Error(message)
 		fmt.Println(myErr.Error())
-		fmt.Printf("For more information, check the log file at %s\n", GetLogFileLocation())
+		fmt.Printf("For more information, check the log file at %s\n", location)
 		fmt.Println("nancy version:", buildversion.BuildVersion)
 		myErr.Exit()
 	}

--- a/cyclonedx/cyclonedx.go
+++ b/cyclonedx/cyclonedx.go
@@ -17,10 +17,10 @@ package cyclonedx
 
 import (
 	"encoding/xml"
-	"fmt"
 
 	"github.com/package-url/packageurl-go"
 	"github.com/sonatype-nexus-community/nancy/customerrors"
+	. "github.com/sonatype-nexus-community/nancy/logger"
 	"github.com/sonatype-nexus-community/nancy/types"
 )
 
@@ -73,7 +73,7 @@ func processPurlsIntoSBOMSchema1_1(results []types.Coordinate) string {
 
 	output, err := xml.MarshalIndent(sbom, " ", "     ")
 	if err != nil {
-		fmt.Print(err)
+		LogLady.Error(err)
 	}
 
 	output = []byte(xml.Header + string(output))

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -16,12 +16,12 @@
 package logger
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/sonatype-nexus-community/nancy/customerrors"
 	"github.com/sonatype-nexus-community/nancy/types"
 )
 
@@ -45,9 +45,7 @@ func doInit(args []string) {
 	}
 
 	file, err := os.OpenFile(GetLogFileLocation(), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
-	if err != nil {
-		fmt.Printf("Could not open log file. error: %v\n", err)
-	}
+	customerrors.Check(err, "Unable to open log file")
 
 	LogLady.Out = file
 	LogLady.Level = logrus.InfoLevel
@@ -83,9 +81,7 @@ func useTestLogFile(args []string) bool {
 func GetLogFileLocation() (result string) {
 	result, _ = os.UserHomeDir()
 	err := os.MkdirAll(path.Join(result, types.OssIndexDirName), os.ModePerm)
-	if err != nil {
-		fmt.Printf("Failed to make all dirs needed to be able to store log file. error: %v\n", err)
-	}
+	customerrors.Check(err, "Unable to create directories necessary for log file")
 	result = path.Join(result, types.OssIndexDirName, DefaultLogFile)
 	return
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -26,13 +26,14 @@ import (
 )
 
 func TestLogger(t *testing.T) {
-	if !strings.Contains(GetLogFileLocation(), TestLogfilename) {
+	location, _ := LogFileLocation()
+	if !strings.Contains(location, TestLogfilename) {
 		t.Errorf("Nancy test file not in log file location. args: %+v", os.Args)
 	}
 
 	LogLady.Info("Test")
 
-	dat, err := ioutil.ReadFile(GetLogFileLocation())
+	dat, err := ioutil.ReadFile(location)
 	if err != nil {
 		t.Error("Unable to open log file")
 	}
@@ -73,7 +74,10 @@ func TestInit(t *testing.T) {
 	teardownTestCase := setupTestCase(t)
 	defer teardownTestCase(t)
 
-	doInit([]string{"yadda", "-test.v"})
+	err := doInit([]string{"yadda", "-test.v"})
+	if err != nil {
+		t.Error(err)
+	}
 	assert.Equal(t, TestLogfilename, DefaultLogFile)
 }
 
@@ -81,7 +85,10 @@ func TestInitIQ(t *testing.T) {
 	teardownTestCase := setupTestCase(t)
 	defer teardownTestCase(t)
 
-	doInit([]string{"yadda", "-iq", "-test.v"})
+	err := doInit([]string{"yadda", "-iq", "-test.v"})
+	if err != nil {
+		t.Error(err)
+	}
 	assert.Equal(t, DefaultLogFilename, DefaultLogFile)
 }
 
@@ -89,6 +96,9 @@ func TestInitDefault(t *testing.T) {
 	teardownTestCase := setupTestCase(t)
 	defer teardownTestCase(t)
 
-	doInit([]string{"yadda", "-yadda"})
+	err := doInit([]string{"yadda", "-yadda"})
+	if err != nil {
+		t.Error(err)
+	}
 	assert.Equal(t, DefaultLogFilename, DefaultLogFile)
 }

--- a/logger/old_logger.go
+++ b/logger/old_logger.go
@@ -1,0 +1,21 @@
+package logger
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/sonatype-nexus-community/nancy/types"
+)
+
+// GetLogFileLocation will return the location on disk of the log file
+func GetLogFileLocation() (result string) {
+	result, _ = os.UserHomeDir()
+	err := os.MkdirAll(path.Join(result, types.OssIndexDirName), os.ModePerm)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	result = path.Join(result, types.OssIndexDirName, DefaultLogFile)
+	return
+}

--- a/logger/old_logger.go
+++ b/logger/old_logger.go
@@ -1,3 +1,18 @@
+// Copyright 2020 Sonatype Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package logger has functions to obtain a logger, and helpers for setting up where the logger writes
 package logger
 
 import (
@@ -9,6 +24,8 @@ import (
 )
 
 // GetLogFileLocation will return the location on disk of the log file
+//
+// Deprecated: Please use LogFileLocation() instead
 func GetLogFileLocation() (result string) {
 	result, _ = os.UserHomeDir()
 	err := os.MkdirAll(path.Join(result, types.OssIndexDirName), os.ModePerm)

--- a/main.go
+++ b/main.go
@@ -248,9 +248,8 @@ func doCheckExistenceAndParse(config configuration.Configuration) {
 			GOPATHs:    []string{getenv},
 		}
 		project, err := ctx.LoadProject()
-		if err != nil {
-			customerrors.Check(err, fmt.Sprintf("could not read lock at path %s", config.Path))
-		}
+		customerrors.Check(err, fmt.Sprintf("could not read lock at path %s", config.Path))
+
 		if project.Lock == nil {
 			customerrors.Check(errors.New("dep failed to parse lock file and returned nil"), "nancy could not continue due to dep failure")
 		}


### PR DESCRIPTION
Working with @DarthHater we went through Nancy and looked for any instances where we were using fmt to print an error and either replaced with a customerror.check or logged with LogLady. 


It relates to the following issue #s:
* Fixes #115 

cc @bhamail / @DarthHater
