### PR TITLE
Exit purge

### DIFF
--- a/audit/csvformatter.go
+++ b/audit/csvformatter.go
@@ -21,6 +21,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"errors"
+	"github.com/sonatype-nexus-community/nancy/customerrors"
 	"strconv"
 
 	. "github.com/sirupsen/logrus"
@@ -119,5 +120,8 @@ func (f *CsvFormatter) Format(entry *Entry) ([]byte, error) {
 }
 
 func (f *CsvFormatter) write(w *csv.Writer, line []string) error {
-	return w.Write(line)
+	if err := w.Write(line); err != nil {
+		return customerrors.NewErrorExitPrintHelp(err, "Failed to write data to csv")
+	}
+	return nil
 }

--- a/audit/csvformatter_test.go
+++ b/audit/csvformatter_test.go
@@ -104,3 +104,23 @@ func TestCsvOutputWhenNotAuditLog(t *testing.T) {
 	assert.NotNil(t, e)
 	assert.Equal(t, errors.New("fields passed did not match the expected values for an audit log. You should probably look at setting the formatter to something else"), e)
 }
+
+func TestCsvFormatter_FormatNoError(t *testing.T) {
+	quiet := true
+	formatter := CsvFormatter{Quiet: &quiet}
+
+	data := map[string]interface{}{
+		"audited": []types.Coordinate{
+			{Coordinates: "auditedCoordinates"},
+		},
+		"invalid": []types.Coordinate{
+			{Coordinates: "invalidCoordinates"},
+		},
+		"num_audited":    0,
+		"num_vulnerable": 0,
+		"version":        "theBuildVersion",
+	}
+	buf, err := formatter.Format(&Entry{Data: data})
+	assert.NoError(t, err)
+	assert.Equal(t, "Summary\nAudited Count,Vulnerable Count,Build Version\n0,0,theBuildVersion\n", string(buf))
+}

--- a/configuration/parse.go
+++ b/configuration/parse.go
@@ -70,7 +70,7 @@ var unixComments = regexp.MustCompile(`#.*$`)
 var untilComment = regexp.MustCompile(`(until=)(.*)`)
 
 func ParseIQ(args []string) (config IqConfiguration, err error) {
-	iqCommand := flag.NewFlagSet("iq", flag.ExitOnError)
+	iqCommand := flag.NewFlagSet("iq", flag.ContinueOnError)
 	iqCommand.BoolVar(&config.Info, "v", false, "Set log level to Info")
 	iqCommand.BoolVar(&config.Debug, "vv", false, "Set log level to Debug")
 	iqCommand.BoolVar(&config.Trace, "vvv", false, "Set log level to Trace")
@@ -88,7 +88,8 @@ func ParseIQ(args []string) (config IqConfiguration, err error) {
 Options:
 `)
 		iqCommand.PrintDefaults()
-		os.Exit(2)
+		//os.Exit(2)
+		// Avoid exit calls, but caller should use exit code 2 when handling
 	}
 
 	ConfigLocation = filepath.Join(HomeDir, types.IQServerDirName, types.IQServerConfigFileName)
@@ -103,7 +104,7 @@ Options:
 		return config, err
 	}
 
-	return config, nil
+	return config, err
 }
 
 func loadConfigFromFile(configLocation string, config *Configuration) error {
@@ -173,7 +174,8 @@ func Parse(args []string) (Configuration, error) {
 Options:
 `)
 		flag.PrintDefaults()
-		os.Exit(2)
+		// os.Exit(2)
+		// Avoid exit calls, but caller should use exit code 2 when handling
 	}
 
 	ConfigLocation = filepath.Join(HomeDir, types.OssIndexDirName, types.OssIndexConfigFileName)

--- a/configuration/parse.go
+++ b/configuration/parse.go
@@ -88,8 +88,6 @@ func ParseIQ(args []string) (config IqConfiguration, err error) {
 Options:
 `)
 		iqCommand.PrintDefaults()
-		//os.Exit(2)
-		// Avoid exit calls, but caller should use exit code 2 when handling
 	}
 
 	ConfigLocation = filepath.Join(HomeDir, types.IQServerDirName, types.IQServerConfigFileName)
@@ -174,8 +172,6 @@ func Parse(args []string) (Configuration, error) {
 Options:
 `)
 		flag.PrintDefaults()
-		// os.Exit(2)
-		// Avoid exit calls, but caller should use exit code 2 when handling
 	}
 
 	ConfigLocation = filepath.Join(HomeDir, types.OssIndexDirName, types.OssIndexConfigFileName)

--- a/configuration/parse_test.go
+++ b/configuration/parse_test.go
@@ -147,3 +147,19 @@ func setup() {
 	HomeDir = "/doesnt/exist"
 	flag.CommandLine = flag.NewFlagSet("", flag.ContinueOnError)
 }
+
+func TestParseUsage(t *testing.T) {
+	setup()
+	_, err := Parse([]string{""})
+	assert.NoError(t, err)
+	// should NOT call os.Exit
+	flag.Usage()
+}
+
+func TestParseIQUsage(t *testing.T) {
+	setup()
+	_, err := ParseIQ([]string{""})
+	assert.NoError(t, err)
+	// should NOT call os.Exit
+	flag.Usage()
+}

--- a/configuration/set.go
+++ b/configuration/set.go
@@ -75,7 +75,7 @@ func GetConfigFromCommandLine(stdin io.Reader) (err error) {
 		// TODO should this return an error, because it means config setup was not completed?
 		return
 	default:
-		LogLady.Infof("User chose invalid config type: %s, recurse madness", str)
+		LogLady.Infof("User chose invalid config type: %s, will retry", str)
 		fmt.Println("Invalid value, 'iq' and 'ossindex' are accepted values, try again!")
 		err = GetConfigFromCommandLine(stdin)
 	}

--- a/configuration/set.go
+++ b/configuration/set.go
@@ -72,9 +72,10 @@ func GetConfigFromCommandLine(stdin io.Reader) (err error) {
 		ConfigLocation = filepath.Join(HomeDir, types.OssIndexDirName, types.OssIndexConfigFileName)
 		err = getAndSetOSSIndexConfig(reader)
 	case "":
+		// TODO this should probably return an error, because it means config setup was not completed
 		return
 	default:
-		LogLady.Info("User chose to set OSS Index config, moving forward")
+		LogLady.Infof("User chose invalid config type: %s, recurse madness", str)
 		fmt.Println("Invalid value, 'iq' and 'ossindex' are accepted values, try again!")
 		err = GetConfigFromCommandLine(stdin)
 	}

--- a/configuration/set.go
+++ b/configuration/set.go
@@ -72,7 +72,7 @@ func GetConfigFromCommandLine(stdin io.Reader) (err error) {
 		ConfigLocation = filepath.Join(HomeDir, types.OssIndexDirName, types.OssIndexConfigFileName)
 		err = getAndSetOSSIndexConfig(reader)
 	case "":
-		// TODO this should probably return an error, because it means config setup was not completed
+		// TODO should this return an error, because it means config setup was not completed?
 		return
 	default:
 		LogLady.Infof("User chose invalid config type: %s, recurse madness", str)
@@ -180,7 +180,7 @@ func marshallAndWriteToDisk(config interface{}) (err error) {
 	}
 
 	LogLady.WithField("config_location", ConfigLocation).Info("Successfully wrote config to disk")
-	fmt.Printf("Successfully wrote config to: %s", ConfigLocation)
+	fmt.Printf("Successfully wrote config to: %s\n", ConfigLocation)
 	return
 }
 

--- a/customerrors/error.go
+++ b/customerrors/error.go
@@ -18,6 +18,8 @@ package customerrors
 
 import (
 	"fmt"
+	"github.com/sonatype-nexus-community/nancy/buildversion"
+	. "github.com/sonatype-nexus-community/nancy/logger"
 )
 
 type ErrorExit struct {
@@ -31,7 +33,23 @@ func (ee ErrorExit) Error() string {
 	if ee.Err != nil {
 		errString = ee.Err.Error()
 	} else {
-		errString = "nil"
+		errString = ""
 	}
 	return fmt.Sprintf("exit code: %d - %s - error: %s", ee.ExitCode, ee.Message, errString)
+}
+
+func NewErrorExitPrintHelp(errCause error, message string) ErrorExit {
+	myErr := ErrorExit{message, errCause, 3}
+	LogLady.WithField("error", errCause).Error(message)
+	fmt.Println(myErr.Error())
+
+	var logFile string
+	var logFileErr error
+	if logFile, logFileErr = LogFileLocation(); logFileErr != nil {
+		logFile = "unknown"
+	}
+
+	fmt.Printf("For more information, check the log file at %s\n", logFile)
+	fmt.Println("nancy version:", buildversion.BuildVersion)
+	return myErr
 }

--- a/customerrors/error.go
+++ b/customerrors/error.go
@@ -37,7 +37,7 @@ func (sw SwError) Exit() {
 	os.Exit(3)
 }
 
-func Check(err error, message string) {
+func Check(err error, message string) error {
 	if err != nil {
 		location, _ := LogFileLocation()
 		myErr := SwError{Message: message, Err: err}
@@ -47,4 +47,15 @@ func Check(err error, message string) {
 		fmt.Println("nancy version:", buildversion.BuildVersion)
 		myErr.Exit()
 	}
+	return err
+}
+
+type ErrorExit struct {
+	Message  string
+	Err      error
+	ExitCode int
+}
+
+func (sw ErrorExit) Error() string {
+	return fmt.Sprintf("exit code: %d - %s - error: %s", sw.ExitCode, sw.Message, sw.Err.Error())
 }

--- a/customerrors/error.go
+++ b/customerrors/error.go
@@ -18,37 +18,7 @@ package customerrors
 
 import (
 	"fmt"
-	"os"
-
-	"github.com/sonatype-nexus-community/nancy/buildversion"
-	. "github.com/sonatype-nexus-community/nancy/logger"
 )
-
-type SwError struct {
-	Message string
-	Err     error
-}
-
-func (sw SwError) Error() string {
-	return fmt.Sprintf("%s - error: %s", sw.Message, sw.Err.Error())
-}
-
-func (sw SwError) Exit() {
-	os.Exit(3)
-}
-
-func Check(err error, message string) error {
-	if err != nil {
-		location, _ := LogFileLocation()
-		myErr := SwError{Message: message, Err: err}
-		LogLady.WithField("error", err).Error(message)
-		fmt.Println(myErr.Error())
-		fmt.Printf("For more information, check the log file at %s\n", location)
-		fmt.Println("nancy version:", buildversion.BuildVersion)
-		myErr.Exit()
-	}
-	return err
-}
 
 type ErrorExit struct {
 	Message  string
@@ -56,6 +26,6 @@ type ErrorExit struct {
 	ExitCode int
 }
 
-func (sw ErrorExit) Error() string {
-	return fmt.Sprintf("exit code: %d - %s - error: %s", sw.ExitCode, sw.Message, sw.Err.Error())
+func (ee ErrorExit) Error() string {
+	return fmt.Sprintf("exit code: %d - %s - error: %s", ee.ExitCode, ee.Message, ee.Err.Error())
 }

--- a/customerrors/error_test.go
+++ b/customerrors/error_test.go
@@ -27,8 +27,17 @@ func TestError(t *testing.T) {
 		ErrorExit{Message: "MyMessage", Err: fmt.Errorf("MyError"), ExitCode: 2}.Error())
 	assert.Equal(t, "exit code: 0 - MyMessage - error: MyError",
 		ErrorExit{Message: "MyMessage", Err: fmt.Errorf("MyError")}.Error())
-	assert.Equal(t, "exit code: 0 - MyMessage - error: nil",
+	assert.Equal(t, "exit code: 0 - MyMessage - error: ",
 		ErrorExit{Message: "MyMessage"}.Error())
-	assert.Equal(t, "exit code: 0 -  - error: nil",
+	assert.Equal(t, "exit code: 0 -  - error: ",
 		ErrorExit{}.Error())
+}
+
+func TestNewErrorExitPrintHelp(t *testing.T) {
+	assert.Equal(t, "exit code: 3 - MyMessage - error: MyError",
+		NewErrorExitPrintHelp(fmt.Errorf("MyError"), "MyMessage").Error())
+	assert.Equal(t, "exit code: 3 - MyMessage - error: ",
+		NewErrorExitPrintHelp(nil, "MyMessage").Error())
+	assert.Equal(t, "exit code: 3 -  - error: ",
+		NewErrorExitPrintHelp(nil, "").Error())
 }

--- a/customerrors/error_test.go
+++ b/customerrors/error_test.go
@@ -18,20 +18,17 @@ package customerrors
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
-type ErrorExit struct {
-	Message  string
-	Err      error
-	ExitCode int
-}
-
-func (ee ErrorExit) Error() string {
-	var errString string
-	if ee.Err != nil {
-		errString = ee.Err.Error()
-	} else {
-		errString = "nil"
-	}
-	return fmt.Sprintf("exit code: %d - %s - error: %s", ee.ExitCode, ee.Message, errString)
+func TestError(t *testing.T) {
+	assert.Equal(t, "exit code: 2 - MyMessage - error: MyError",
+		ErrorExit{Message: "MyMessage", Err: fmt.Errorf("MyError"), ExitCode: 2}.Error())
+	assert.Equal(t, "exit code: 0 - MyMessage - error: MyError",
+		ErrorExit{Message: "MyMessage", Err: fmt.Errorf("MyError")}.Error())
+	assert.Equal(t, "exit code: 0 - MyMessage - error: nil",
+		ErrorExit{Message: "MyMessage"}.Error())
+	assert.Equal(t, "exit code: 0 -  - error: nil",
+		ErrorExit{}.Error())
 }

--- a/cyclonedx/cyclonedx.go
+++ b/cyclonedx/cyclonedx.go
@@ -33,7 +33,7 @@ const version = "1"
 
 // ProcessPurlsIntoSBOM will take a slice of packageurl.PackageURL and convert them
 // into a minimal 1.1 CycloneDX sbom
-func ProcessPurlsIntoSBOM(results []types.Coordinate) string {
+func ProcessPurlsIntoSBOM(results []types.Coordinate) (string, error) {
 	return processPurlsIntoSBOMSchema1_1(results)
 }
 
@@ -91,7 +91,9 @@ func processPurlsIntoSBOMSchema1_1(results []types.Coordinate) string {
 	sbom := createSbomDocument()
 	for _, v := range results {
 		purl, err := packageurl.FromString(v.Coordinates)
-		customerrors.Check(err, "Error parsing purl from given coordinate")
+		if err != nil {
+			return "", err
+		}
 
 		component := types.Component{
 			Type:    "library",
@@ -141,5 +143,5 @@ func processAndReturnSbom(sbom *types.Sbom) string {
 
 	output = []byte(xml.Header + string(output))
 
-	return string(output)
+	return string(output), err
 }

--- a/cyclonedx/cyclonedx.go
+++ b/cyclonedx/cyclonedx.go
@@ -19,6 +19,7 @@ package cyclonedx
 
 import (
 	"encoding/xml"
+	"github.com/sonatype-nexus-community/nancy/customerrors"
 
 	"github.com/package-url/packageurl-go"
 	. "github.com/sonatype-nexus-community/nancy/logger"
@@ -91,6 +92,7 @@ func processPurlsIntoSBOMSchema1_1(results []types.Coordinate) string {
 	for _, v := range results {
 		purl, err := packageurl.FromString(v.Coordinates)
 		if err != nil {
+			_ = customerrors.NewErrorExitPrintHelp(err, "Error parsing purl from given coordinate")
 			return ""
 		}
 

--- a/cyclonedx/cyclonedx.go
+++ b/cyclonedx/cyclonedx.go
@@ -21,7 +21,6 @@ import (
 	"encoding/xml"
 
 	"github.com/package-url/packageurl-go"
-	"github.com/sonatype-nexus-community/nancy/customerrors"
 	. "github.com/sonatype-nexus-community/nancy/logger"
 	"github.com/sonatype-nexus-community/nancy/types"
 )
@@ -33,7 +32,7 @@ const version = "1"
 
 // ProcessPurlsIntoSBOM will take a slice of packageurl.PackageURL and convert them
 // into a minimal 1.1 CycloneDX sbom
-func ProcessPurlsIntoSBOM(results []types.Coordinate) (string, error) {
+func ProcessPurlsIntoSBOM(results []types.Coordinate) string {
 	return processPurlsIntoSBOMSchema1_1(results)
 }
 
@@ -92,7 +91,7 @@ func processPurlsIntoSBOMSchema1_1(results []types.Coordinate) string {
 	for _, v := range results {
 		purl, err := packageurl.FromString(v.Coordinates)
 		if err != nil {
-			return "", err
+			return ""
 		}
 
 		component := types.Component{
@@ -143,5 +142,5 @@ func processAndReturnSbom(sbom *types.Sbom) string {
 
 	output = []byte(xml.Header + string(output))
 
-	return string(output), err
+	return string(output)
 }

--- a/cyclonedx/cyclonedx_test.go
+++ b/cyclonedx/cyclonedx_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/package-url/packageurl-go"
 	"github.com/shopspring/decimal"
 	"github.com/sonatype-nexus-community/nancy/types"
-	assert "gopkg.in/go-playground/assert.v1"
+	"gopkg.in/go-playground/assert.v1"
 )
 
 func TestCreateSBOMFromPackageURLs(t *testing.T) {
@@ -104,7 +104,7 @@ func TestCreateSBOMFromSHA1s(t *testing.T) {
 }
 
 func TestProcessPurlsIntoSBOM(t *testing.T) {
-	results := []types.Coordinate{}
+	var results []types.Coordinate
 	crypto := types.Coordinate{
 		Coordinates:     "pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
 		Reference:       "https://ossindex.sonatype.org/component/pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
@@ -128,7 +128,8 @@ func TestProcessPurlsIntoSBOM(t *testing.T) {
 		Reference:       "https://ossindex.sonatype.org/component/pkg:golang/github.com/go-yaml/yaml@v2.2.2",
 		Vulnerabilities: []types.Vulnerability{},
 	})
-	result := ProcessPurlsIntoSBOM(results)
+	result, err := ProcessPurlsIntoSBOM(results)
+	assert.Equal(t, nil, err)
 
 	doc := etree.NewDocument()
 
@@ -211,4 +212,37 @@ func assertBaseXMLValid(doc *etree.Element, t *testing.T) {
 	assert.Equal(t, doc.Attr[1].Value, "http://cyclonedx.org/schema/ext/vulnerability/1.0")
 	assert.Equal(t, doc.Attr[2].Key, "version")
 	assert.Equal(t, doc.Attr[2].Value, "1")
+}
+
+func TestProcess1_1NoError(t *testing.T) {
+	var results []types.Coordinate
+	sbom, err := processPurlsIntoSBOMSchema1_1(results)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?>
+ <bom xmlns="http://cyclonedx.org/schema/bom/1.1" xmlns:v="http://cyclonedx.org/schema/ext/vulnerability/1.0" version="1">
+      <components></components>
+ </bom>`, sbom)
+}
+
+func TestProcess1_1WithCoordinate(t *testing.T) {
+	results := []types.Coordinate{
+		{
+			Coordinates: "BADpkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
+		},
+	}
+
+	sbom, err := processPurlsIntoSBOMSchema1_1(results)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "scheme is missing", err.Error())
+	assert.Equal(t, "", sbom)
+}
+
+func TestProcessWithError(t *testing.T) {
+	var results []types.Coordinate
+	sbom, err := ProcessPurlsIntoSBOM(results)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?>
+ <bom xmlns="http://cyclonedx.org/schema/bom/1.1" xmlns:v="http://cyclonedx.org/schema/ext/vulnerability/1.0" version="1">
+      <components></components>
+ </bom>`, sbom)
 }

--- a/cyclonedx/cyclonedx_test.go
+++ b/cyclonedx/cyclonedx_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestCreateSBOMFromPackageURLs(t *testing.T) {
-	results := []packageurl.PackageURL{}
+	var results []packageurl.PackageURL
 	uno, _ := packageurl.FromString("pkg:golang/github.com/test/test@1.0.0")
 	results = append(results, uno)
 
@@ -65,7 +65,7 @@ func TestCreateSBOMFromPackageURLs(t *testing.T) {
 }
 
 func TestCreateSBOMFromSHA1s(t *testing.T) {
-	results := []types.Sha1SBOM{}
+	var results []types.Sha1SBOM
 	uno := types.Sha1SBOM{Location: "/path/on/disk", Sha1: "c2843e01d9a2"}
 	results = append(results, uno)
 
@@ -128,8 +128,7 @@ func TestProcessPurlsIntoSBOM(t *testing.T) {
 		Reference:       "https://ossindex.sonatype.org/component/pkg:golang/github.com/go-yaml/yaml@v2.2.2",
 		Vulnerabilities: []types.Vulnerability{},
 	})
-	result, err := ProcessPurlsIntoSBOM(results)
-	assert.Equal(t, nil, err)
+	result := ProcessPurlsIntoSBOM(results)
 
 	doc := etree.NewDocument()
 
@@ -216,8 +215,7 @@ func assertBaseXMLValid(doc *etree.Element, t *testing.T) {
 
 func TestProcess1_1NoError(t *testing.T) {
 	var results []types.Coordinate
-	sbom, err := processPurlsIntoSBOMSchema1_1(results)
-	assert.Equal(t, nil, err)
+	sbom := processPurlsIntoSBOMSchema1_1(results)
 	assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?>
  <bom xmlns="http://cyclonedx.org/schema/bom/1.1" xmlns:v="http://cyclonedx.org/schema/ext/vulnerability/1.0" version="1">
       <components></components>
@@ -231,16 +229,13 @@ func TestProcess1_1WithCoordinate(t *testing.T) {
 		},
 	}
 
-	sbom, err := processPurlsIntoSBOMSchema1_1(results)
-	assert.NotEqual(t, nil, err)
-	assert.Equal(t, "scheme is missing", err.Error())
+	sbom := processPurlsIntoSBOMSchema1_1(results)
 	assert.Equal(t, "", sbom)
 }
 
 func TestProcessWithError(t *testing.T) {
 	var results []types.Coordinate
-	sbom, err := ProcessPurlsIntoSBOM(results)
-	assert.Equal(t, nil, err)
+	sbom := ProcessPurlsIntoSBOM(results)
 	assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?>
  <bom xmlns="http://cyclonedx.org/schema/bom/1.1" xmlns:v="http://cyclonedx.org/schema/ext/vulnerability/1.0" version="1">
       <components></components>

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -95,10 +95,7 @@ func AuditPackages(purls []string, applicationID string, config configuration.Iq
 		return statusURLResp, customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "There was an issue auditing packages using OSS Index"}
 	}
 
-	sbom, err := cyclonedx.ProcessPurlsIntoSBOM(resultsFromOssIndex)
-	if err != nil {
-		return types.StatusURLResult{}, err
-	}
+	sbom := cyclonedx.ProcessPurlsIntoSBOM(resultsFromOssIndex)
 	LogLady.WithField("sbom", sbom).Debug("Obtained cyclonedx SBOM")
 
 	LogLady.WithFields(logrus.Fields{

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -65,6 +65,11 @@ type thirdPartyAPIResult struct {
 
 var statusURLResp types.StatusURLResult
 
+type resultError struct {
+	finished bool
+	err      error
+}
+
 // AuditPackages accepts a slice of purls, public application ID, and configuration, and will submit these to
 // Nexus IQ Server for audit, and return a struct of StatusURLResult
 func AuditPackages(purls []string, applicationID string, config configuration.IqConfiguration) (types.StatusURLResult, error) {
@@ -86,16 +91,24 @@ func AuditPackages(purls []string, applicationID string, config configuration.Iq
 	}
 
 	resultsFromOssIndex, err := ossindex.AuditPackages(purls) //nolint deprecation
-	customerrors.Check(err, "There was an issue auditing packages using OSS Index")
+	if err != nil {
+		return statusURLResp, customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "There was an issue auditing packages using OSS Index"}
+	}
 
-	sbom := cyclonedx.ProcessPurlsIntoSBOM(resultsFromOssIndex)
+	sbom, err := cyclonedx.ProcessPurlsIntoSBOM(resultsFromOssIndex)
+	if err != nil {
+		return types.StatusURLResult{}, err
+	}
 	LogLady.WithField("sbom", sbom).Debug("Obtained cyclonedx SBOM")
 
 	LogLady.WithFields(logrus.Fields{
 		"internal_id": internalID,
 		"sbom":        sbom,
 	}).Debug("Submitting to Third Party API")
-	statusURL := submitToThirdPartyAPI(sbom, internalID)
+	statusURL, err := submitToThirdPartyAPI(sbom, internalID)
+	if err != nil {
+		return statusURLResp, customerrors.ErrorExit{ExitCode: 3, Err: err}
+	}
 	if statusURL == "" {
 		LogLady.Error("StatusURL not obtained from Third Party API")
 		return statusURLResp, fmt.Errorf("There was an issue submitting your sbom to the Nexus IQ Third Party API, sbom: %s", sbom)
@@ -103,22 +116,24 @@ func AuditPackages(purls []string, applicationID string, config configuration.Iq
 
 	statusURLResp = types.StatusURLResult{}
 
-	finished := make(chan bool)
+	finishedChan := make(chan resultError)
 
-	go func() {
+	go func() resultError {
 		for {
 			select {
-			case <-finished:
-				return
+			case <-finishedChan:
+				return resultError{finished: true}
 			default:
-				pollIQServer(fmt.Sprintf("%s/%s", localConfig.Server, statusURL), finished, localConfig.MaxRetries)
+				if err = pollIQServer(fmt.Sprintf("%s/%s", localConfig.Server, statusURL), finishedChan, localConfig.MaxRetries); err != nil {
+					return resultError{finished: false, err: err}
+				}
 				time.Sleep(pollInterval)
 			}
 		}
 	}()
 
-	<-finished
-	return statusURLResp, nil
+	r := <-finishedChan
+	return statusURLResp, r.err
 }
 
 func getInternalApplicationID(applicationID string) (string, error) {
@@ -129,22 +144,32 @@ func getInternalApplicationID(applicationID string) (string, error) {
 		fmt.Sprintf("%s%s%s", localConfig.Server, internalApplicationIDURL, applicationID),
 		nil,
 	)
-	customerrors.Check(err, "Request to get internal application id failed")
+	if err != nil {
+		return "", customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "Request to get internal application id failed"}
+	}
 
 	req.SetBasicAuth(localConfig.User, localConfig.Token)
 	req.Header.Set("User-Agent", useragent.GetUserAgent())
 
 	resp, err := client.Do(req)
-	customerrors.Check(err, "There was an error communicating with Nexus IQ Server to get your internal application ID")
+	if err != nil {
+		return "", customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "There was an error communicating with Nexus IQ Server to get your internal application ID"}
+	}
 
+	//noinspection GoUnhandledErrorResult
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusOK {
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
-		customerrors.Check(err, "There was an error retrieving the bytes of the response for getting your internal application ID from Nexus IQ Server")
+		if err != nil {
+			return "", customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "There was an error retrieving the bytes of the response for getting your internal application ID from Nexus IQ Server"}
+		}
 
 		var response applicationResponse
-		customerrors.Check(json.Unmarshal(bodyBytes, &response), "failed to unmarshal response")
+		err = json.Unmarshal(bodyBytes, &response)
+		if err != nil {
+			return "", customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "failed to unmarshal response"}
+		}
 
 		if response.Applications != nil && len(response.Applications) > 0 {
 			LogLady.WithFields(logrus.Fields{
@@ -166,7 +191,7 @@ func getInternalApplicationID(applicationID string) (string, error) {
 	return "", fmt.Errorf("Unable to communicate with Nexus IQ Server, status code returned is: %d", resp.StatusCode)
 }
 
-func submitToThirdPartyAPI(sbom string, internalID string) string {
+func submitToThirdPartyAPI(sbom string, internalID string) (string, error) {
 	LogLady.Debug("Beginning to submit to Third Party API")
 	client := &http.Client{}
 
@@ -178,26 +203,35 @@ func submitToThirdPartyAPI(sbom string, internalID string) string {
 		url,
 		bytes.NewBuffer([]byte(sbom)),
 	)
-	customerrors.Check(err, "Could not POST to Nexus iQ Third Party API")
+	if err != nil {
+		return "", customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "Could not POST to Nexus iQ Third Party API"}
+	}
 
 	req.SetBasicAuth(localConfig.User, localConfig.Token)
 	req.Header.Set("User-Agent", useragent.GetUserAgent())
 	req.Header.Set("Content-Type", "application/xml")
 
 	resp, err := client.Do(req)
-	customerrors.Check(err, "There was an issue communicating with the Nexus IQ Third Party API")
+	if err != nil {
+		return "", customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "There was an issue communicating with the Nexus IQ Third Party API"}
+	}
 
+	//noinspection GoUnhandledErrorResult
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusAccepted {
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		LogLady.WithField("body", string(bodyBytes)).Info("Request accepted")
-		customerrors.Check(err, "There was an issue submitting your sbom to the Nexus IQ Third Party API")
+		if err != nil {
+			return "", customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "There was an issue submitting your sbom to the Nexus IQ Third Party API"}
+		}
 
 		var response thirdPartyAPIResult
 		err = json.Unmarshal(bodyBytes, &response)
-		customerrors.Check(err, "Could not unmarshal response from iQ server")
-		return response.StatusURL
+		if err != nil {
+			return "", customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "Could not unmarshal response from iQ server"}
+		}
+		return response.StatusURL, err
 	}
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	LogLady.WithFields(logrus.Fields{
@@ -205,12 +239,14 @@ func submitToThirdPartyAPI(sbom string, internalID string) string {
 		"status_code": resp.StatusCode,
 		"status":      resp.Status,
 	}).Info("Request not accepted")
-	customerrors.Check(err, "There was an issue submitting your sbom to the Nexus IQ Third Party API")
+	if err != nil {
+		return "", customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "There was an issue submitting your sbom to the Nexus IQ Third Party API"}
+	}
 
-	return ""
+	return "", err
 }
 
-func pollIQServer(statusURL string, finished chan bool, maxRetries int) {
+func pollIQServer(statusURL string, finished chan resultError, maxRetries int) error {
 	LogLady.WithFields(logrus.Fields{
 		"attempt_number": tries,
 		"max_retries":    maxRetries,
@@ -218,12 +254,14 @@ func pollIQServer(statusURL string, finished chan bool, maxRetries int) {
 	}).Trace("Polling Nexus IQ for response")
 	if tries > maxRetries {
 		LogLady.Error("Maximum tries exceeded, finished polling, consider bumping up Max Retries")
-		finished <- true
+		finished <- resultError{finished: true, err: nil}
 	}
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", statusURL, nil)
-	customerrors.Check(err, "Could not poll iQ server")
+	if err != nil {
+		return customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "Could not poll iQ server"}
+	}
 
 	req.SetBasicAuth(localConfig.User, localConfig.Token)
 
@@ -232,27 +270,33 @@ func pollIQServer(statusURL string, finished chan bool, maxRetries int) {
 	resp, err := client.Do(req)
 
 	if err != nil {
-		finished <- true
-		customerrors.Check(err, "There was an error polling Nexus IQ Server")
+		finished <- resultError{finished: true, err: err}
+		return customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "There was an error polling Nexus IQ Server"}
 	}
 
+	//noinspection GoUnhandledErrorResult
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusOK {
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
-		customerrors.Check(err, "There was an error with processing the response from polling Nexus IQ Server")
+		if err != nil {
+			return customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "There was an error with processing the response from polling Nexus IQ Server"}
+		}
 
 		var response types.StatusURLResult
 		err = json.Unmarshal(bodyBytes, &response)
-		customerrors.Check(err, "Could not unmarshal response from iQ server")
+		if err != nil {
+			return customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "Could not unmarshal response from iQ server"}
+		}
 		statusURLResp = response
 		if response.IsError {
-			finished <- true
+			finished <- resultError{finished: true, err: nil}
 		}
-		finished <- true
+		finished <- resultError{finished: true, err: nil}
 	}
 	tries++
 	fmt.Print(".")
+	return err
 }
 
 func warnUserOfBadLifeChoices() {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -28,7 +28,8 @@ import (
 )
 
 func TestLogger(t *testing.T) {
-	location, _ := LogFileLocation()
+	location, err := LogFileLocation()
+	assert.NoError(t, err)
 	if !strings.Contains(location, TestLogfilename) {
 		t.Errorf("Nancy test file not in log file location. args: %+v", os.Args)
 	}

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 	}
 
 	if err != nil {
-		if exiterr, ok := err.(*customerrors.ErrorExit); ok {
+		if exiterr, ok := err.(customerrors.ErrorExit); ok {
 			os.Exit(exiterr.ExitCode)
 		} else {
 			// really don't expect this
@@ -76,6 +76,7 @@ func doOssi(ossiArgs []string) (err error) {
 		return
 	}
 	if err = processConfig(ossIndexConfig); err != nil {
+		LogLady.Info("Nancy finished parsing config for OSS Index, vulnerability found")
 		return
 	}
 	LogLady.Info("Nancy finished parsing config for OSS Index")
@@ -355,6 +356,7 @@ func checkOSSIndex(purls []string, invalidpurls []string, config configuration.C
 
 	if count := audit.LogResults(config.Formatter, packageCount, coordinates, invalidCoordinates, config.CveList.Cves); count > 0 {
 		// return error with number of vulnerable items found
+		fmt.Printf("Found vuln count: %d\n", count)
 		return customerrors.ErrorExit{ExitCode: count}
 	}
 	return nil

--- a/main.go
+++ b/main.go
@@ -99,6 +99,7 @@ func doIq(iqArgs []string) (err error) {
 	}
 	LogLady.WithField("config", config).Info("Obtained IQ config")
 	if err = processIQConfig(config); err != nil {
+		LogLady.Info("Nancy finished parsing config for IQ, vulnerability found")
 		return
 	}
 	LogLady.Info("Nancy finished parsing config for IQ")

--- a/main.go
+++ b/main.go
@@ -225,7 +225,7 @@ func processIQConfig(config configuration.IqConfiguration) (err error) {
 	if config.Application == "" {
 		LogLady.Info("No application specified, printing usage and exiting with error")
 		flag.Usage()
-		err = customerrors.ErrorExit{ExitCode: 2}
+		err = customerrors.NewErrorExitPrintHelp(fmt.Errorf("no IQ application id specified"), "Missing IQ application ID")
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -65,7 +65,6 @@ func main() {
 			os.Exit(4)
 		}
 	}
-	fmt.Println("byeeeeee") // probably shouldn't get here until other exit cases above are all covered.
 }
 
 func doOssi(ossiArgs []string) (err error) {

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func processIQConfig(config configuration.IqConfiguration) (err error) {
 	}
 
 	if config.Application == "" {
-		LogLady.Info("No application specified, printing usage and exiting clean")
+		LogLady.Info("No application specified, printing usage and exiting with error")
 		flag.Usage()
 		err = customerrors.ErrorExit{ExitCode: 2}
 		return

--- a/main_test.go
+++ b/main_test.go
@@ -111,9 +111,14 @@ func TestDoConfigInvalidHomeDir(t *testing.T) {
 	stdin.Write([]byte("ossindex\nmyOssiUsername\nmyOssiToken\n"))
 	err := doConfig(&stdin)
 	assert.Error(t, err)
-	if exiterr, ok := err.(*os.PathError); ok {
-		assert.Equal(t, "mkdir", exiterr.Op)
-		assert.Equal(t, "/no/such/dir/.ossindex", exiterr.Path)
+	if exiterr, ok := err.(customerrors.ErrorExit); ok {
+		assert.Equal(t, "Unable to set config for Nancy", exiterr.Message)
+		if errCause, ok := exiterr.Err.(*os.PathError); ok {
+			assert.Equal(t, "mkdir", errCause.Op)
+			assert.Equal(t, "/no/such/dir/.ossindex", errCause.Path)
+		} else {
+			t.Fail()
+		}
 	} else {
 		t.Fail()
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -77,7 +77,7 @@ func TestDoIqExitError(t *testing.T) {
 	err := doIq([]string{"server-url"})
 	assert.Error(t, err)
 	if exiterr, ok := err.(customerrors.ErrorExit); ok {
-		assert.Equal(t, 2, exiterr.ExitCode)
+		assert.Equal(t, 3, exiterr.ExitCode)
 	} else {
 		t.Fail()
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -66,7 +66,7 @@ func TestProcessIQConfigApplicationMissing(t *testing.T) {
 	err := processIQConfig(configuration.IqConfiguration{})
 	assert.Error(t, err)
 	if exiterr, ok := err.(customerrors.ErrorExit); ok {
-		assert.Equal(t, 2, exiterr.ExitCode)
+		assert.Equal(t, 3, exiterr.ExitCode)
 	} else {
 		t.Fail()
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -17,7 +17,13 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"github.com/sonatype-nexus-community/nancy/configuration"
+	"github.com/sonatype-nexus-community/nancy/customerrors"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -31,5 +37,182 @@ func TestBadArgs(t *testing.T) {
 	if err != nil && !strings.Contains(sout, "flag provided but not defined: -bad") {
 		fmt.Println(sout) // so we can see the full output
 		t.Errorf("%v", err)
+	}
+}
+
+func TestProcessIQConfigHelp(t *testing.T) {
+	err := processIQConfig(configuration.IqConfiguration{Help: true})
+	assert.Error(t, err)
+	if exiterr, ok := err.(customerrors.ErrorExit); ok {
+		assert.Equal(t, 0, exiterr.ExitCode)
+	} else {
+		t.Fail()
+	}
+}
+
+func TestProcessIQConfigVersion(t *testing.T) {
+	err := processIQConfig(configuration.IqConfiguration{Version: true})
+	assert.Error(t, err)
+	if exiterr, ok := err.(customerrors.ErrorExit); ok {
+		assert.Equal(t, 0, exiterr.ExitCode)
+	} else {
+		t.Fail()
+	}
+}
+
+func TestProcessIQConfigApplicationMissing(t *testing.T) {
+	// NOTE: Usage func will not have been setup here, since configuration.ParseIQ() has not yet been called
+	err := processIQConfig(configuration.IqConfiguration{})
+	assert.Error(t, err)
+	if exiterr, ok := err.(customerrors.ErrorExit); ok {
+		assert.Equal(t, 2, exiterr.ExitCode)
+	} else {
+		t.Fail()
+	}
+}
+
+func TestDoIqExitError(t *testing.T) {
+	// NOTE: Usage func will be setup by call to configuration.ParseIQ()
+	err := doIq([]string{"server-url"})
+	assert.Error(t, err)
+	if exiterr, ok := err.(customerrors.ErrorExit); ok {
+		assert.Equal(t, 2, exiterr.ExitCode)
+	} else {
+		t.Fail()
+	}
+}
+
+func TestDoIqInvalidFlag(t *testing.T) {
+	// This case would call os.Exit() due to Flag parsing set to flag.ExitOnError
+	// therefore, changed to flag.ContinueOnError
+	err := doIq([]string{"-badflag"})
+	assert.Error(t, err)
+	if exiterr, ok := err.(customerrors.ErrorExit); ok {
+		assert.Equal(t, 2, exiterr.ExitCode)
+	} else {
+		t.Fail()
+	}
+}
+
+func TestDoConfigInvalidType(t *testing.T) {
+	var stdin bytes.Buffer
+	stdin.Write([]byte("yadda\n"))
+	err := doConfig(&stdin)
+	// TODO this should probably return an error
+	assert.NoError(t, err)
+}
+
+func TestDoConfigInvalidHomeDir(t *testing.T) {
+	configuration.HomeDir = "/no/such/dir"
+	defer resetConfig(t)
+
+	var stdin bytes.Buffer
+	stdin.Write([]byte("ossindex\nmyOssiUsername\nmyOssiToken\n"))
+	err := doConfig(&stdin)
+	assert.Error(t, err)
+	if exiterr, ok := err.(*os.PathError); ok {
+		assert.Equal(t, "mkdir", exiterr.Op)
+		assert.Equal(t, "/no/such/dir/.ossindex", exiterr.Path)
+	} else {
+		t.Fail()
+	}
+}
+
+func setupConfig(t *testing.T) (tempDir string) {
+	tempDir, err := ioutil.TempDir("", "config-test")
+	assert.NoError(t, err)
+	configuration.HomeDir = tempDir
+	return tempDir
+}
+
+func resetConfig(t *testing.T) {
+	var err error
+	configuration.HomeDir, err = os.UserHomeDir()
+	assert.NoError(t, err)
+}
+
+func TestDoConfigOssIndex(t *testing.T) {
+	tempDir := setupConfig(t)
+	defer resetConfig(t)
+	defer os.RemoveAll(tempDir) // clean up
+
+	var stdin bytes.Buffer
+	stdin.Write([]byte("ossindex\nmyOssiUsername\nmyOssiToken\n"))
+	err := doConfig(&stdin)
+	assert.NoError(t, err)
+}
+
+func TestDoConfigIq(t *testing.T) {
+	tempDir := setupConfig(t)
+	defer resetConfig(t)
+	defer os.RemoveAll(tempDir) // clean up
+
+	var stdin bytes.Buffer
+	stdin.Write([]byte("iq\nmyIqServer\nmyIqUsername\nmyIqToken\n"))
+	err := doConfig(&stdin)
+	assert.NoError(t, err)
+}
+
+func TestProcessConfigHelp(t *testing.T) {
+	err := processConfig(configuration.Configuration{Help: true})
+	assert.Error(t, err)
+	if exiterr, ok := err.(customerrors.ErrorExit); ok {
+		assert.Equal(t, 0, exiterr.ExitCode)
+	} else {
+		t.Fail()
+	}
+}
+
+func TestProcessConfigVersion(t *testing.T) {
+	err := processConfig(configuration.Configuration{Version: true})
+	assert.Error(t, err)
+	if exiterr, ok := err.(customerrors.ErrorExit); ok {
+		assert.Equal(t, 0, exiterr.ExitCode)
+	} else {
+		t.Fail()
+	}
+}
+
+func TestProcessConfigCleanCache(t *testing.T) {
+	err := processConfig(configuration.Configuration{CleanCache: true})
+	assert.NoError(t, err)
+}
+
+func TestCheckStdInInvalid(t *testing.T) {
+	err := checkStdIn()
+	if exiterr, ok := err.(customerrors.ErrorExit); ok {
+		assert.Equal(t, 1, exiterr.ExitCode)
+	} else {
+		t.Fail()
+	}
+}
+
+func TestCheckStdInValid(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "fakeStdIn")
+	assert.Nil(t, err)
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	content := []byte("yadda\n")
+	if _, err := tmpfile.Write(content); err != nil {
+		assert.NoError(t, err)
+	}
+	if _, err := tmpfile.Seek(0, 0); err != nil {
+		assert.NoError(t, err)
+	}
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }() // Restore original Stdin
+	os.Stdin = tmpfile
+
+	err = checkStdIn()
+	assert.NoError(t, err)
+}
+
+func TestDoOssi(t *testing.T) {
+	err := doOssi([]string{""})
+	assert.Error(t, err)
+	if exiterr, ok := err.(customerrors.ErrorExit); ok {
+		assert.Equal(t, 1, exiterr.ExitCode)
+	} else {
+		t.Fail()
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"github.com/sonatype-nexus-community/nancy/audit"
 	"github.com/sonatype-nexus-community/nancy/configuration"
 	"github.com/sonatype-nexus-community/nancy/customerrors"
 	"github.com/stretchr/testify/assert"
@@ -134,6 +135,7 @@ func resetConfig(t *testing.T) {
 func TestDoConfigOssIndex(t *testing.T) {
 	tempDir := setupConfig(t)
 	defer resetConfig(t)
+	//noinspection GoUnhandledErrorResult
 	defer os.RemoveAll(tempDir) // clean up
 
 	var stdin bytes.Buffer
@@ -145,6 +147,7 @@ func TestDoConfigOssIndex(t *testing.T) {
 func TestDoConfigIq(t *testing.T) {
 	tempDir := setupConfig(t)
 	defer resetConfig(t)
+	//noinspection GoUnhandledErrorResult
 	defer os.RemoveAll(tempDir) // clean up
 
 	var stdin bytes.Buffer
@@ -190,6 +193,7 @@ func TestCheckStdInInvalid(t *testing.T) {
 func TestCheckStdInValid(t *testing.T) {
 	tmpfile, err := ioutil.TempFile("", "fakeStdIn")
 	assert.Nil(t, err)
+	//noinspection GoUnhandledErrorResult
 	defer os.Remove(tmpfile.Name()) // clean up
 
 	content := []byte("yadda\n")
@@ -204,6 +208,17 @@ func TestCheckStdInValid(t *testing.T) {
 	os.Stdin = tmpfile
 
 	err = checkStdIn()
+	assert.NoError(t, err)
+}
+
+func TestCheckOSSIndexNoneVulnerable(t *testing.T) {
+	// TODO find way to mock ossindex url for this test, probably just move checkOSSIndex() method to ossindex package
+	purls := []string{"pkg:github/BurntSushi/toml@0.3.1"}
+	invalidPurls := []string{"invalidPurl"}
+	noColor := true
+	quiet := true
+	config := configuration.Configuration{Formatter: &audit.AuditLogTextFormatter{Quiet: &quiet, NoColor: &noColor}}
+	err := checkOSSIndex(purls, invalidPurls, config)
 	assert.NoError(t, err)
 }
 

--- a/ossindex/internal/cache/cache.go
+++ b/ossindex/internal/cache/cache.go
@@ -49,6 +49,7 @@ type DBValue struct {
 
 func (c *Cache) getDatabasePath() (dbDir string) {
 	usr, err := user.Current()
+	// TODO Change this to return error, replace customerrors.Check()
 	customerrors.Check(err, "Error getting user home")
 
 	return path.Join(usr.HomeDir, types.OssIndexDirName, dbDirName, c.DBName)

--- a/ossindex/internal/cache/cache.go
+++ b/ossindex/internal/cache/cache.go
@@ -50,7 +50,7 @@ type DBValue struct {
 func (c *Cache) getDatabasePath() (dbDir string, err error) {
 	usr, err := user.Current()
 	if err != nil {
-		return "", customerrors.ErrorExit{ExitCode: 3, Err: err, Message: "Error getting user home"}
+		return "", customerrors.NewErrorExitPrintHelp(err, "Error getting user home")
 	}
 
 	return path.Join(usr.HomeDir, types.OssIndexDirName, dbDirName, c.DBName), err

--- a/ossindex/ossindex.go
+++ b/ossindex/ossindex.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/sonatype-nexus-community/nancy/configuration"
-	"github.com/sonatype-nexus-community/nancy/customerrors"
 	. "github.com/sonatype-nexus-community/nancy/logger"
 	"github.com/sonatype-nexus-community/nancy/ossindex/internal/cache"
 	"github.com/sonatype-nexus-community/nancy/types"
@@ -83,7 +82,9 @@ func AuditPackagesWithOSSIndex(purls []string, config *configuration.Configurati
 
 func doAuditPackages(purls []string, config *configuration.Configuration) ([]types.Coordinate, error) {
 	newPurls, results, err := dbCache.GetCacheValues(purls)
-	customerrors.Check(err, "Error initializing cache")
+	if err != nil {
+		return nil, err
+	}
 
 	chunks := chunk(newPurls, MaxCoords)
 
@@ -146,7 +147,7 @@ func doRequestToOSSIndex(jsonStr []byte, config *configuration.Configuration) (c
 	}
 
 	// Process results
-	if err = json.Unmarshal([]byte(body), &coordinates); err != nil {
+	if err = json.Unmarshal(body, &coordinates); err != nil {
 		LogLady.WithField("error", err).Error("Error unmarshalling response from OSS Index")
 		return
 	}

--- a/ossindex/ossindex.go
+++ b/ossindex/ossindex.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/sonatype-nexus-community/nancy/customerrors"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -83,7 +84,7 @@ func AuditPackagesWithOSSIndex(purls []string, config *configuration.Configurati
 func doAuditPackages(purls []string, config *configuration.Configuration) ([]types.Coordinate, error) {
 	newPurls, results, err := dbCache.GetCacheValues(purls)
 	if err != nil {
-		return nil, err
+		return nil, customerrors.NewErrorExitPrintHelp(err, "Error initializing cache")
 	}
 
 	chunks := chunk(newPurls, MaxCoords)

--- a/packages/mod.go
+++ b/packages/mod.go
@@ -62,7 +62,7 @@ func (m Mod) ExtractPurlsFromManifestForIQ() (purls []string) {
 
 func (m Mod) CheckExistenceOfManifest() (bool, error) {
 	if _, err := os.Stat(m.GoSumPath); os.IsNotExist(err) {
-		return false, customerrors.ErrorExit{ExitCode: 3, Err: err, Message: fmt.Sprint("No go.sum found at path: " + m.GoSumPath)}
+		return false, customerrors.NewErrorExitPrintHelp(err, fmt.Sprint("No go.sum found at path: "+m.GoSumPath))
 	}
 	return true, nil
 }

--- a/packages/mod.go
+++ b/packages/mod.go
@@ -60,11 +60,11 @@ func (m Mod) ExtractPurlsFromManifestForIQ() (purls []string) {
 	return
 }
 
-func (m Mod) CheckExistenceOfManifest() bool {
+func (m Mod) CheckExistenceOfManifest() (bool, error) {
 	if _, err := os.Stat(m.GoSumPath); os.IsNotExist(err) {
-		customerrors.Check(err, fmt.Sprint("No go.sum found at path: "+m.GoSumPath))
+		return false, customerrors.ErrorExit{ExitCode: 3, Err: err, Message: fmt.Sprint("No go.sum found at path: " + m.GoSumPath)}
 	}
-	return true
+	return true, nil
 }
 
 func removeDuplicates(purls []string) (dedupedPurls []string) {

--- a/packages/mod_test.go
+++ b/packages/mod_test.go
@@ -17,6 +17,7 @@
 package packages
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/sonatype-nexus-community/nancy/types"
@@ -66,7 +67,8 @@ func appendProject(name string, version string, projectList *types.ProjectList) 
 func TestModCheckExistenceOfManifestExists(t *testing.T) {
 	mod := Mod{}
 	mod.GoSumPath = testGoSumName
-	exists := mod.CheckExistenceOfManifest()
+	exists, err := mod.CheckExistenceOfManifest()
+	assert.NoError(t, err)
 
 	if !exists {
 		t.Errorf("Expected existence of %s", testGoSumName)
@@ -74,13 +76,9 @@ func TestModCheckExistenceOfManifestExists(t *testing.T) {
 }
 
 func TestModExtractPurlsFromManifest(t *testing.T) {
-	var err error
 	mod := Mod{}
 	mod.GoSumPath = testGoSumName
 	mod.ProjectList = getProjectList()
-	if err != nil {
-		t.Error(err)
-	}
 
 	result := mod.ExtractPurlsFromManifest()
 	if len(result) != 5 {
@@ -89,13 +87,9 @@ func TestModExtractPurlsFromManifest(t *testing.T) {
 }
 
 func TestModExtractPurlsFromManifestDuplicates(t *testing.T) {
-	var err error
 	mod := Mod{}
 	mod.GoSumPath = testGoSumName
 	mod.ProjectList = getProjectListDuplicates()
-	if err != nil {
-		t.Error(err)
-	}
 
 	result := mod.ExtractPurlsFromManifest()
 	if len(result) != 5 {


### PR DESCRIPTION
Minimize places where we call os.Exit(), in preparation for conversion to using Cobra #134 

I think this is ready for review.

I was a little concerned about the CI build failing in the logger_test.go. Seemed to be an unrelated change. Rerunning the CI build and it just passed. Boggle. We should keep an eye out in case this is a heisenbug. 

BTW, we may have a decision point regarding "--command, -flag" syntax in the near future.

Fixes #78

cc @bhamail / @DarthHater
