### PR TITLE
Some additional SBOM types to support upstream projects

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -116,6 +116,12 @@ type StatusURLResult struct {
 
 // CycloneDX Types
 
+// Sha1SBOM is a struct to begin assembling a minimal SBOM based on sha1s
+type Sha1SBOM struct {
+	Location string
+	Sha1     string
+}
+
 // Sbom is a struct to begin assembling a minimal SBOM
 type Sbom struct {
 	XMLName    xml.Name   `xml:"bom"`
@@ -136,8 +142,19 @@ type Component struct {
 	BomRef          string          `xml:"bom-ref,attr"`
 	Name            string          `xml:"name"`
 	Version         string          `xml:"version"`
-	Purl            string          `xml:"purl"`
+	Group           string          `xml:"group,omitempty"`
+	Purl            string          `xml:"purl,omitempty"`
+	Hashes          Hashes          `xml:"hashes,omitempty"`
 	Vulnerabilities Vulnerabilities `xml:"v:vulnerabilities,omitempty"`
+}
+
+type Hashes struct {
+	Hash []Hash `xml:"hash,omitempty"`
+}
+
+type Hash struct {
+	Alg       string `xml:"alg,attr,omitempty"`
+	Attribute string `xml:",chardata"`
 }
 
 type Vulnerabilities struct {


### PR DESCRIPTION
For some additional projects (Ahab, Cheque, Hashbrowns), I figured we could extend Nancy to have the core cyclonedx functionality necessary to support additional use cases for generating different types of SBOMs

This pull request makes the following changes:
* Adds a SBOM processor for a slice of `types.Sha1SBOM` (supports Hashbrowns)
* Adds a SBOM processor for a slice of `packageurl.PackageURL` (Ahab, Cheque, and likely Nancy)
* Adds tests for verifying these
* Adds `group` to SBOM output as that was missing previously to packageurl and purl processors

cc @bhamail / @DarthHater
