### PR TITLE
indenting package string cleanly independent of package index

### DIFF
--- a/audit/auditlogtextformatter.go
+++ b/audit/auditlogtextformatter.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
@@ -47,9 +48,13 @@ type AuditLogTextFormatter struct {
 }
 
 func logPackage(sb *strings.Builder, noColor bool, idx int, packageCount int, coordinate types.Coordinate) {
+	w := tabwriter.NewWriter(sb, 9, 3, 0, '\t', 0)
+	w.Flush()
+
 	au := aurora.NewAurora(!noColor)
+
 	sb.WriteString(
-		fmt.Sprintf("[%d/%d] %s\n",
+		fmt.Sprintf("[%d/%d]\t%s\n",
 			idx,
 			packageCount,
 			au.Bold(au.Green(coordinate.Coordinates)).String(),
@@ -63,9 +68,13 @@ func logInvalidSemVerWarning(sb *strings.Builder, noColor bool, quiet bool, inva
 			au := aurora.NewAurora(!noColor)
 			sb.WriteString(au.Red("!!!!! WARNING !!!!!\nScanning cannot be completed on the following package(s) since they do not use semver.\n").String())
 
+			w := tabwriter.NewWriter(sb, 9, 3, 0, '\t', 0)
+			w.Init(sb, 9, 3, 0, '\t', 0)
+			w.Flush()
+
 			for k, v := range invalidPurls {
 				sb.WriteString(
-					fmt.Sprintf("[%d/%d] %s\n",
+					fmt.Sprintf("[%d/%d]\t%s\n",
 						k+1,
 						len(invalidPurls),
 						au.Bold(v.Coordinates).String(),
@@ -81,8 +90,12 @@ func logInvalidSemVerWarning(sb *strings.Builder, noColor bool, quiet bool, inva
 func logVulnerablePackage(sb *strings.Builder, noColor bool, idx int, packageCount int, coordinate types.Coordinate) {
 	au := aurora.NewAurora(!noColor)
 
+	w := tabwriter.NewWriter(sb, 9, 3, 0, '\t', 0)
+	w.Init(sb, 9, 3, 0, '\t', 0)
+	w.Flush()
+
 	sb.WriteString(fmt.Sprintf(
-		"[%d/%d] %s\n%s \n",
+		"[%d/%d]\t%s\n%s \n",
 		idx,
 		packageCount,
 		au.Bold(au.Red(coordinate.Coordinates)).String(),

--- a/audit/auditlogtextformatter.go
+++ b/audit/auditlogtextformatter.go
@@ -69,7 +69,6 @@ func logInvalidSemVerWarning(sb *strings.Builder, noColor bool, quiet bool, inva
 			sb.WriteString(au.Red("!!!!! WARNING !!!!!\nScanning cannot be completed on the following package(s) since they do not use semver.\n").String())
 
 			w := tabwriter.NewWriter(sb, 9, 3, 0, '\t', 0)
-			w.Init(sb, 9, 3, 0, '\t', 0)
 			w.Flush()
 
 			for k, v := range invalidPurls {
@@ -91,7 +90,6 @@ func logVulnerablePackage(sb *strings.Builder, noColor bool, idx int, packageCou
 	au := aurora.NewAurora(!noColor)
 
 	w := tabwriter.NewWriter(sb, 9, 3, 0, '\t', 0)
-	w.Init(sb, 9, 3, 0, '\t', 0)
 	w.Flush()
 
 	sb.WriteString(fmt.Sprintf(

--- a/audit/auditlogtextformatter.go
+++ b/audit/auditlogtextformatter.go
@@ -48,9 +48,6 @@ type AuditLogTextFormatter struct {
 }
 
 func logPackage(sb *strings.Builder, noColor bool, idx int, packageCount int, coordinate types.Coordinate) {
-	w := tabwriter.NewWriter(sb, 9, 3, 0, '\t', 0)
-	w.Flush()
-
 	au := aurora.NewAurora(!noColor)
 
 	sb.WriteString(
@@ -67,9 +64,6 @@ func logInvalidSemVerWarning(sb *strings.Builder, noColor bool, quiet bool, inva
 		if len(invalidPurls) > 0 {
 			au := aurora.NewAurora(!noColor)
 			sb.WriteString(au.Red("!!!!! WARNING !!!!!\nScanning cannot be completed on the following package(s) since they do not use semver.\n").String())
-
-			w := tabwriter.NewWriter(sb, 9, 3, 0, '\t', 0)
-			w.Flush()
 
 			for k, v := range invalidPurls {
 				sb.WriteString(
@@ -88,10 +82,6 @@ func logInvalidSemVerWarning(sb *strings.Builder, noColor bool, quiet bool, inva
 
 func logVulnerablePackage(sb *strings.Builder, noColor bool, idx int, packageCount int, coordinate types.Coordinate) {
 	au := aurora.NewAurora(!noColor)
-
-	w := tabwriter.NewWriter(sb, 9, 3, 0, '\t', 0)
-	w.Flush()
-
 	sb.WriteString(fmt.Sprintf(
 		"[%d/%d]\t%s\n%s \n",
 		idx,
@@ -178,6 +168,9 @@ func (f *AuditLogTextFormatter) Format(entry *Entry) ([]byte, error) {
 		numVulnerable := entry.Data["num_vulnerable"].(int)
 
 		var sb strings.Builder
+
+		w := tabwriter.NewWriter(&sb, 9, 3, 0, '\t', 0)
+		w.Flush()
 
 		logInvalidSemVerWarning(&sb, *f.NoColor, *f.Quiet, invalidEntries)
 		nonVulnerablePackages, vulnerablePackages := splitPackages(auditedEntries)


### PR DESCRIPTION
<!--

    Copyright 2018-present Sonatype Inc.

    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

        http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.

-->

This pull request makes the following changes:
* Imported tabwriter to align package string independent of package index

**BEFORE**
<img width="819" alt="image" src="https://user-images.githubusercontent.com/34050448/82743410-01f8ca00-9d39-11ea-93db-6a96c6ce568b.png">


**AFTER**
<img width="700" alt="image" src="https://user-images.githubusercontent.com/34050448/82743368-71ba8500-9d38-11ea-830b-018683c785d5.png">


cc @bhamail / @DarthHater
