### PR TITLE
make `--clean-cache` available as root command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Flags:
 
 Global Flags:
   -v, -- count            Set log level, multiple v's is more verbose
-  -c, --clean-cache       Deletes local cache directory
       --loud              indicate output should include non-vulnerable packages
   -p, --path string       Specify a path to a dep Gopkg.lock file for scanning
   -q, --quiet             indicate output should contain only packages with vulnerabilities (default true)
@@ -113,7 +112,6 @@ Flags:
 
 Global Flags:
   -v, -- count            Set log level, multiple v's is more verbose
-  -c, --clean-cache       Deletes local cache directory
       --loud              indicate output should include non-vulnerable packages
   -p, --path string       Specify a path to a dep Gopkg.lock file for scanning
   -q, --quiet             indicate output should contain only packages with vulnerabilities (default true)

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -65,6 +65,16 @@ func TestRootCommandUnknownCommand(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown command \"one\" for \"nancy\"")
 }
 
+func TestRootCommandCleanCache(t *testing.T) {
+	origConfig := configOssi
+	defer func() {
+		configOssi = origConfig
+	}()
+	output, err := executeCommand(rootCmd, "-c")
+	assert.Equal(t, output, "")
+	assert.Nil(t, err)
+}
+
 func TestProcessConfigInvalidStdIn(t *testing.T) {
 	origConfig := configOssi
 	defer func() {
@@ -77,7 +87,7 @@ func TestProcessConfigInvalidStdIn(t *testing.T) {
 	assert.Equal(t, stdInInvalid, err)
 }
 
-func TestProcessConfigCleanCacheError(t *testing.T) {
+func TestDoRootCleanCacheError(t *testing.T) {
 	origConfig := configOssi
 	defer func() {
 		configOssi = origConfig
@@ -94,8 +104,9 @@ func TestProcessConfigCleanCacheError(t *testing.T) {
 	}()
 	ossiCreator = &ossiFactoryMock{mockOssiServer: mockOssiServer{auditPackagesErr: expectedError}}
 
-	err := processConfig()
-	assert.Equal(t, expectedError, err)
+	err := doRoot(nil, nil)
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), expectedError.Error()), err.Error())
 }
 
 func TestProcessConfigPath(t *testing.T) {


### PR DESCRIPTION
Having the `--clean-cache` only available via `sleuth` is awkward because clearing the cache is not specific to the `sleuth` command. Clearing the cache would also affect the `iq` command - in that a call to ossi would always occur after the cache is cleared.

When the clear impl was only in the `sleuth` command, there was a bug that allowed a CLI call like: `nancy -c` to appear to succeed, but the cache was not actually cleared. This was because the `-c` was valid everywhere (a "PersistentFlag" in Cobra lingo), but was ONLY implemented in the `sleuth` call stack.

This PR makes the `--clean-cache` occur as part of the rootCmd.

cc @bhamail / @DarthHater
