### PR TITLE
Use goreleaser to build native linux installers

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -110,3 +110,13 @@ dockers:
     - "sonatypecommunity/nancy:{{ .Tag }}-alpine"
     - "sonatypecommunity/nancy:v{{ .Major }}-alpine"
     - "sonatypecommunity/nancy:v{{ .Major }}.{{ .Minor }}-alpine"
+
+nfpms:
+  -
+    vendor: sonatype-nexus-community
+    homepage: https://github.com/sonatype-nexus-community/nancy
+    description: "A tool to check for vulnerabilities in your Golang dependencies, powered by Sonatype OSS Index"
+    formats:
+      - apk
+      - deb
+      - rpm


### PR DESCRIPTION
Because goreleaser rocks! These config changes will build native linux installers: .deb, .rpm, and .apk

Probably need more work to deal with signing, etc, but this is a first step.

cc @bhamail / @DarthHater
