### PR TITLE
Add failure notification for Jenkins.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,5 +43,7 @@ dockerizedBuildPipeline(
   },
   onFailure: {
     githubStatusUpdate('failure')
+    notifyChat(currentBuild: currentBuild, env: env, room: 'community-oss-fun')
+    sendEmailNotification(currentBuild, env, [], 'community-group@sonatype.com')
   }
 )


### PR DESCRIPTION
Let folks know when Jenkins builds fail.

This pull request makes the following changes:
* Sends a build notification to the #community-oss-fun Slack channel
* Sends a build notification to community-group@sonatype.com


cc @bhamail / @DarthHater
