### PR TITLE
Update audit log format

### DIFF
--- a/internal/audit/auditlogtextformatter.go
+++ b/internal/audit/auditlogtextformatter.go
@@ -47,13 +47,11 @@ type AuditLogTextFormatter struct {
 	NoColor bool
 }
 
-func logPackage(sb *strings.Builder, noColor bool, idx int, packageCount int, coordinate types.Coordinate) {
+func logPackage(sb *strings.Builder, noColor bool, coordinate types.Coordinate) {
 	au := aurora.NewAurora(!noColor)
 
 	sb.WriteString(
-		fmt.Sprintf("[%d/%d]\t%s\n",
-			idx,
-			packageCount,
+		fmt.Sprintf("%s\n",
 			au.Bold(au.Green(coordinate.Coordinates)).String(),
 		),
 	)
@@ -65,11 +63,9 @@ func logInvalidSemVerWarning(sb *strings.Builder, noColor bool, quiet bool, inva
 			au := aurora.NewAurora(!noColor)
 			sb.WriteString(au.Red("!!!!! WARNING !!!!!\nScanning cannot be completed on the following package(s) since they do not use semver.\n").String())
 
-			for k, v := range invalidPurls {
+			for _, v := range invalidPurls {
 				sb.WriteString(
-					fmt.Sprintf("[%d/%d]\t%s\n",
-						k+1,
-						len(invalidPurls),
+					fmt.Sprintf("%s\n",
 						au.Bold(v.Coordinates).String(),
 					),
 				)
@@ -80,12 +76,10 @@ func logInvalidSemVerWarning(sb *strings.Builder, noColor bool, quiet bool, inva
 	}
 }
 
-func logVulnerablePackage(sb *strings.Builder, noColor bool, idx int, packageCount int, coordinate types.Coordinate) {
+func logVulnerablePackage(sb *strings.Builder, noColor bool, coordinate types.Coordinate) {
 	au := aurora.NewAurora(!noColor)
 	sb.WriteString(fmt.Sprintf(
-		"[%d/%d]\t%s\n%s \n",
-		idx,
-		packageCount,
+		"%s\n%s \n",
 		au.Bold(au.Red(coordinate.Coordinates)).String(),
 		au.Red(strconv.Itoa(len(coordinate.Vulnerabilities))+" known vulnerabilities affecting installed version").String(),
 	))
@@ -142,16 +136,17 @@ func scoreAssessment(score decimal.Decimal) string {
 
 func groupAndPrint(vulnerable []types.Coordinate, nonVulnerable []types.Coordinate, quiet bool, noColor bool, sb *strings.Builder) {
 	if !quiet {
-		sb.WriteString("\nNon Vulnerable Packages\n\n")
-		for k, v := range nonVulnerable {
-			logPackage(sb, noColor, k+1, len(nonVulnerable), v)
+		sb.WriteString("\n")
+		for _, v := range nonVulnerable {
+			logPackage(sb, noColor, v)
 		}
+		sb.WriteString(fmt.Sprintf("\n%d Non Vulnerable Packages\n\n", len(nonVulnerable)))
 	}
 	if len(vulnerable) > 0 {
-		sb.WriteString("\nVulnerable Packages\n\n")
-		for k, v := range vulnerable {
-			logVulnerablePackage(sb, noColor, k+1, len(vulnerable), v)
+		for _, v := range vulnerable {
+			logVulnerablePackage(sb, noColor, v)
 		}
+		sb.WriteString(fmt.Sprintf("\n%d Vulnerable Packages\n\n", len(vulnerable)))
 	}
 }
 

--- a/internal/audit/auditlogtextformatter_test.go
+++ b/internal/audit/auditlogtextformatter_test.go
@@ -88,7 +88,7 @@ func TestFormatterLogInvalidSemVerWarning(t *testing.T) {
 
 	expectedMessagePrefix := `!!!!! WARNING !!!!!
 Scanning cannot be completed on the following package(s) since they do not use semver.
-[1/1]	MyInvalidCoords
+MyInvalidCoords
 
 `
 	assert.True(t, strings.HasPrefix(string(logMessage), expectedMessagePrefix))

--- a/internal/audit/auditlogtextformatter_test.go
+++ b/internal/audit/auditlogtextformatter_test.go
@@ -18,9 +18,10 @@ package audit
 
 import (
 	"errors"
-	"github.com/shopspring/decimal"
 	"strings"
 	"testing"
+
+	"github.com/shopspring/decimal"
 
 	. "github.com/sirupsen/logrus"
 	"github.com/sonatype-nexus-community/go-sona-types/ossindex/types"
@@ -59,7 +60,7 @@ func verifyFormatterSummaryLoudness(t *testing.T, quiet bool) {
 
 	expectedSummary := "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n┃ Summary                     ┃\n┣━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━┫\n┃ Audited Dependencies    ┃ 0 ┃\n┣━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━┫\n┃ Vulnerable Dependencies ┃ \x1b[1;31m0\x1b[0m ┃\n┗━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━┛\n"
 	if !quiet {
-		expectedSummary = "\nNon Vulnerable Packages\n\n" + expectedSummary
+		expectedSummary = "\n\n0 Non Vulnerable Packages\n\n" + expectedSummary
 	}
 	assert.Equal(t, expectedSummary, string(logMessage))
 }


### PR DESCRIPTION
Dropped running count when printing dependency names to avoid alignment issues when processing large numbers of dependencies.

This pull request makes the following changes:
* Print total count at end of scanning vs incremental progress
* Update tests for new format

It relates to the following issue #s:
* Fixes #154 

cc @bhamail / @DarthHater / @MichelKazi 
