### PR TITLE
Command to output SBOM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/nightlyone/lockfile v1.0.0 // indirect
+	github.com/package-url/packageurl-go v0.1.0
 	github.com/pelletier/go-toml v1.8.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sdboyer/constext v0.0.0-20170321163424-836a14457353 // indirect

--- a/internal/cmd/sbom.go
+++ b/internal/cmd/sbom.go
@@ -1,0 +1,77 @@
+//
+// Copyright 2018-present Sonatype Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/package-url/packageurl-go"
+	"github.com/sonatype-nexus-community/go-sona-types/cyclonedx"
+	"github.com/sonatype-nexus-community/nancy/internal/customerrors"
+	"github.com/sonatype-nexus-community/nancy/internal/logger"
+	"github.com/spf13/cobra"
+)
+
+var sbomCmd = &cobra.Command{
+	Use:     "sbom",
+	Example: `  go list -json -m all | nancy sbom`,
+	Short:   "Output a CycloneDX Software Bill Of Materials",
+	Long:    `'nancy sbom' is a command to output a CycloneDX Software Bill Of Materials`,
+	RunE:    doSbom,
+}
+
+//noinspection GoUnusedParameter
+func doSbom(cmd *cobra.Command, args []string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var ok bool
+			err, ok = r.(error)
+			if !ok {
+				err = fmt.Errorf("pkg: %v", r)
+			}
+			err = customerrors.ErrorShowLogPath{Err: err}
+		}
+	}()
+
+	logLady = logger.GetLogger("", configOssi.LogLevel)
+	logLady.Info("Nancy parsing config for generating SBOM")
+
+	var purls []string
+	purls, err = getPurls()
+
+	var packageUrls []packageurl.PackageURL
+
+	for _, v := range purls {
+		purl, err := packageurl.FromString(v)
+		if err != nil {
+			logLady.WithError(err).Error("unexpected error in sbom cmd")
+		}
+		packageUrls = append(packageUrls, purl)
+	}
+
+	cyclonedx := cyclonedx.Default(logLady)
+
+	sbom := cyclonedx.FromPackageURLs(packageUrls)
+
+	fmt.Print(sbom)
+
+	return
+}
+
+func init() {
+	rootCmd.AddCommand(sbomCmd)
+}


### PR DESCRIPTION
Did this real quick, but this outputs an sbom to the command line

This pull request makes the following changes:
* Adds `sbom` command
* Does the dance to get an sbom and outputs it

It relates to the following issue #s:
* Fixes #144

cc @bhamail / @DarthHater / @ButterB0wl 
