### PR TITLE
Update logger to isolate test code to tests

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -17,16 +17,13 @@ package logger
 
 import (
 	"fmt"
-	"os"
-	"path"
-	"strings"
-
 	"github.com/sirupsen/logrus"
 	"github.com/sonatype-nexus-community/nancy/types"
+	"os"
+	"path"
 )
 
 const DefaultLogFilename = "nancy.combined.log"
-const TestLogfilename = "nancy.test.log"
 
 // DefaultLogFile can be overridden to use a different file name for upstream consumers
 var DefaultLogFile = DefaultLogFilename
@@ -36,14 +33,10 @@ var DefaultLogFile = DefaultLogFilename
 var LogLady = logrus.New()
 
 func init() {
-	doInit(os.Args)
+	doInit()
 }
 
-func doInit(args []string) {
-	if useTestLogFile(args) {
-		DefaultLogFile = TestLogfilename
-	}
-
+func doInit() {
 	file, err := os.OpenFile(GetLogFileLocation(), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
 	if err != nil {
 		fmt.Printf("Could not open log file. error: %v\n", err)
@@ -52,31 +45,6 @@ func doInit(args []string) {
 	LogLady.Out = file
 	LogLady.Level = logrus.InfoLevel
 	LogLady.Formatter = &logrus.JSONFormatter{}
-}
-
-func stringPrefixInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if strings.Contains(b, a) {
-			return true
-		}
-	}
-	return false
-}
-
-func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
-}
-
-func useTestLogFile(args []string) bool {
-	if stringPrefixInSlice("-test.", args) && !stringInSlice("-iq", args) {
-		return true
-	}
-	return false
 }
 
 // GetLogFileLocation will return the location on disk of the log file


### PR DESCRIPTION
Updates logging code to not contain test code paths as requested in https://github.com/sonatype-nexus-community/nancy/issues/122.

I'm seeing some weirdness on a couple tests, couldn't figure out what was up with the original logic of updating the test directory if it a test flag was passed in but not an IQ test?

* Fixes https://github.com/sonatype-nexus-community/nancy/issues/122
* Assists me in acquiring a t-shirt

cc @bhamail / @DarthHater
