### PR TITLE
Cleanup Jenkinsfile to use Makefile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,11 +23,10 @@ dockerizedBuildPipeline(
   },
   buildAndTest: {
     sh '''
-    go mod download
-    go mod tidy
     go get -u github.com/jstemmer/go-junit-report
-    go test ./... -v 2>&1 -p=1 | go-junit-report > test-results.xml
-    CGO_ENABLED=0 GOOS=linux go build -o nancy .
+    make deps
+    make test | go-junit-report > $TEST_RESULTS/gotest/report.xml
+    make build
     '''
   },
   vulnerabilityScan: {


### PR DESCRIPTION
It relates to the following issue #s:
* Fixes #120

Just simply making things consistent where we can. CircleCi uses Makefile and we use it locally. So we should use it in the Jenkinsfile as well. 

cc @bhamail / @DarthHater
