### PR TITLE
use new AbsoluteReportHTMLURL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sdboyer/constext v0.0.0-20170321163424-836a14457353 // indirect
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.6.0
-	github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210125205443-b273115053f3
+	github.com/sonatype-nexus-community/go-sona-types v0.0.10
 	github.com/spf13/afero v1.3.4 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sdboyer/constext v0.0.0-20170321163424-836a14457353 // indirect
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.6.0
-	github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120184112-9e0b57586976
+	github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120224358-4efb99fc34ae
 	github.com/spf13/afero v1.3.4 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sdboyer/constext v0.0.0-20170321163424-836a14457353 // indirect
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.6.0
-	github.com/sonatype-nexus-community/go-sona-types v0.0.8
+	github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120184112-9e0b57586976
 	github.com/spf13/afero v1.3.4 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sdboyer/constext v0.0.0-20170321163424-836a14457353 // indirect
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.6.0
-	github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120224358-4efb99fc34ae
+	github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210125205443-b273115053f3
 	github.com/spf13/afero v1.3.4 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -257,12 +257,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
-github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120184112-9e0b57586976 h1:ohNqIdnP4bezJ3Pp4K1IVOxaRpwG/Q+0+57gRKuiGbw=
-github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120184112-9e0b57586976/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
-github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120223632-69ca35650b6b h1:8QcORbUL8zlkxPhcVGTQTdcZWdLHp3itA0ufbn07/j0=
-github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120223632-69ca35650b6b/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
-github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120224358-4efb99fc34ae h1:84YdfsxnxdToJKBdJClL4quwQZNR3ry5v7/meMIo0uk=
-github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120224358-4efb99fc34ae/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
+github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210125205443-b273115053f3 h1:UaN4whlAsVLMq9hIgENZvb2RXzsWBkSUflFYq8uctNE=
+github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210125205443-b273115053f3/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.3.4 h1:8q6vk3hthlpb2SouZcnBVKboxWQWMDNF38bwholZrJc=

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,10 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120184112-9e0b57586976 h1:ohNqIdnP4bezJ3Pp4K1IVOxaRpwG/Q+0+57gRKuiGbw=
 github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120184112-9e0b57586976/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
+github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120223632-69ca35650b6b h1:8QcORbUL8zlkxPhcVGTQTdcZWdLHp3itA0ufbn07/j0=
+github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120223632-69ca35650b6b/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
+github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120224358-4efb99fc34ae h1:84YdfsxnxdToJKBdJClL4quwQZNR3ry5v7/meMIo0uk=
+github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120224358-4efb99fc34ae/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.3.4 h1:8q6vk3hthlpb2SouZcnBVKboxWQWMDNF38bwholZrJc=

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
-github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210125205443-b273115053f3 h1:UaN4whlAsVLMq9hIgENZvb2RXzsWBkSUflFYq8uctNE=
-github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210125205443-b273115053f3/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
+github.com/sonatype-nexus-community/go-sona-types v0.0.10 h1:VW+OE1vAjBwwRCz7jz4xcBbUn1j3bz1gFnEw1YYmYGs=
+github.com/sonatype-nexus-community/go-sona-types v0.0.10/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.3.4 h1:8q6vk3hthlpb2SouZcnBVKboxWQWMDNF38bwholZrJc=

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
-github.com/sonatype-nexus-community/go-sona-types v0.0.8 h1:6xb9BIC2w3y4kF/xQA25Zs6Yrl8ZqFkfH77AKPaG4RA=
-github.com/sonatype-nexus-community/go-sona-types v0.0.8/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
+github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120184112-9e0b57586976 h1:ohNqIdnP4bezJ3Pp4K1IVOxaRpwG/Q+0+57gRKuiGbw=
+github.com/sonatype-nexus-community/go-sona-types v0.0.10-0.20210120184112-9e0b57586976/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.3.4 h1:8q6vk3hthlpb2SouZcnBVKboxWQWMDNF38bwholZrJc=

--- a/internal/cmd/iq.go
+++ b/internal/cmd/iq.go
@@ -92,9 +92,6 @@ var iqCmd = &cobra.Command{
 	RunE:   doIQ,
 }
 
-const policyActionFailure = "Failure"
-const policyActionWarning = "Warning"
-
 //noinspection GoUnusedParameter
 func doIQ(cmd *cobra.Command, args []string) (err error) {
 	defer func() {
@@ -255,7 +252,7 @@ func auditWithIQServer(purls []string) error {
 	logLady.WithField("res", res).Debug("Successful in communicating with IQ Server")
 	showPolicyActionMessage(res, os.Stdout)
 	switch res.PolicyAction {
-	case policyActionFailure:
+	case iq.PolicyActionFailure:
 		return customerrors.ErrorExit{ExitCode: 1}
 	}
 	return nil
@@ -263,10 +260,10 @@ func auditWithIQServer(purls []string) error {
 
 func showPolicyActionMessage(res iq.StatusURLResult, writer io.Writer) {
 	switch res.PolicyAction {
-	case policyActionFailure:
+	case iq.PolicyActionFailure:
 		_, _ = fmt.Fprintln(writer, "Hi, Nancy here, you have some policy violations to clean up!")
 		_, _ = fmt.Fprintln(writer, "Report URL: ", res.AbsoluteReportHTMLURL)
-	case policyActionWarning:
+	case iq.PolicyActionWarning:
 		_, _ = fmt.Fprintln(writer, "Read, read, read. That's all I can say. There are policy warnings to investigate!")
 		_, _ = fmt.Fprintln(writer, "Report URL: ", res.AbsoluteReportHTMLURL)
 	default:

--- a/internal/cmd/iq_test.go
+++ b/internal/cmd/iq_test.go
@@ -403,8 +403,8 @@ func TestIqCreatorOptionsLogging(t *testing.T) {
 
 func Test_showPolicyActionMessage(t *testing.T) {
 	verifyReportURL(t, "anythingElse") //default policy action
-	verifyReportURL(t, policyActionWarning)
-	verifyReportURL(t, policyActionFailure)
+	verifyReportURL(t, iq.PolicyActionWarning)
+	verifyReportURL(t, iq.PolicyActionFailure)
 }
 
 func verifyReportURL(t *testing.T, policyAction string) {


### PR DESCRIPTION
As of IQ 104, the report urls returned in the old field are relative urls. This PR uses a new field populated with an absolute url for viewing the report.

TODO: Update to use a released version of `go-sona-types` when possible.

cc @bhamail / @DarthHater
