### PR TITLE
change development version to be semver compliant, and remove related…

### DIFF
--- a/buildversion/version.go
+++ b/buildversion/version.go
@@ -18,7 +18,7 @@ package buildversion
 
 var (
 	// these are overwritten/populated via build CLI
-	BuildVersion = "development"
+	BuildVersion = "0.0.0-dev"
 	BuildTime    = ""
 	BuildCommit  = ""
 )

--- a/buildversion/version_test.go
+++ b/buildversion/version_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestDefaultVersion(t *testing.T) {
-	assert.Equal(t, "development", BuildVersion)
+	assert.Equal(t, "0.0.0-dev", BuildVersion)
 }
 
 func TestDefaultBuildTime(t *testing.T) {

--- a/internal/cmd/check.go
+++ b/internal/cmd/check.go
@@ -44,13 +44,12 @@ func checkForUpdates(gitHubAPI string) error {
 		logAndShowMessage("Checking for updates...")
 
 		logLady.WithFields(logrus.Fields{
-			"gitHubAPI":       gitHubAPI,
-			"BuildVersion":    buildversion.BuildVersion,
-			"current version": getVersionNumberSemver(),
-			"PackageManager":  buildversion.PackageManager(),
+			"gitHubAPI":      gitHubAPI,
+			"BuildVersion":   buildversion.BuildVersion,
+			"PackageManager": buildversion.PackageManager(),
 		}).Debug("before CheckForUpdates")
 
-		check, err := update.CheckForUpdates(gitHubAPI, update.NancySlug, getVersionNumberSemver(), buildversion.PackageManager())
+		check, err := update.CheckForUpdates(gitHubAPI, update.NancySlug, buildversion.BuildVersion, buildversion.PackageManager())
 
 		if err != nil {
 			logLady.Error("error checking for updates: " + err.Error())
@@ -86,17 +85,6 @@ func checkForUpdates(gitHubAPI string) error {
 	}
 
 	return nil
-}
-
-func getVersionNumberSemver() (currentVersion string) {
-	// this value will be overridden during release, but for dev, we need a semver compliant value
-	if //goland:noinspection GoBoolExpressions
-	buildversion.BuildVersion == "development" {
-		currentVersion = "0.0.0"
-	} else {
-		currentVersion = buildversion.BuildVersion
-	}
-	return currentVersion
 }
 
 func logAndShowMessage(message string) {

--- a/internal/cmd/check_test.go
+++ b/internal/cmd/check_test.go
@@ -17,29 +17,10 @@
 package cmd
 
 import (
-	"github.com/blang/semver"
 	"github.com/sirupsen/logrus/hooks/test"
-	"github.com/sonatype-nexus-community/nancy/buildversion"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
-
-func TestGetVersionNumberSemver(t *testing.T) {
-	origBuildVersion := buildversion.BuildVersion
-	defer func() {
-		buildversion.BuildVersion = origBuildVersion
-	}()
-
-	// check default ("development")
-	semver.MustParse(getVersionNumberSemver())
-
-	// check explicit "development"
-	buildversion.BuildVersion = "development"
-	semver.MustParse(getVersionNumberSemver())
-
-	buildversion.BuildVersion = "1.2.3"
-	semver.MustParse(getVersionNumberSemver())
-}
 
 func TestCheckForUpdates(t *testing.T) {
 	logLady, _ = test.NewNullLogger()

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -59,7 +59,7 @@ func updateCLI(gitHubAPI string, performUpdate bool) error {
 		}).Debug()
 	}
 
-	check, err := update.CheckForUpdates(gitHubAPI, update.NancySlug, getVersionNumberSemver(), buildversion.PackageManager())
+	check, err := update.CheckForUpdates(gitHubAPI, update.NancySlug, buildversion.BuildVersion, buildversion.PackageManager())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
While looking into self-update logic, I realized I can delete some cruft by just changing the default development build version to be a semver compliant string.

cc @bhamail / @DarthHater
