### PR TITLE
skip update check features

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,16 @@ Available Commands:
   update      Check if there are any updates available
 
 Flags:
-  -v, -- count            Set log level, multiple v's is more verbose
-  -c, --clean-cache       Deletes local cache directory
-  -h, --help              help for nancy
-      --loud              indicate output should include non-vulnerable packages
-  -p, --path string       Specify a path to a dep Gopkg.lock file for scanning
-  -q, --quiet             indicate output should contain only packages with vulnerabilities (default true)
-  -t, --token string      Specify OSS Index API token for request
-  -u, --username string   Specify OSS Index username for request
-  -V, --version           Get the version
+  -v, -- count              Set log level, multiple v's is more verbose
+  -c, --clean-cache         Deletes local cache directory
+  -h, --help                help for nancy
+      --loud                indicate output should include non-vulnerable packages
+  -p, --path string         Specify a path to a dep Gopkg.lock file for scanning
+  -q, --quiet               indicate output should contain only packages with vulnerabilities (default true)
+      --skip-update-check   Skip the check for updates.
+  -t, --token string        Specify OSS Index API token for request
+  -u, --username string     Specify OSS Index username for request
+  -V, --version             Get the version
 
 Use "nancy [command] --help" for more information about a command.
 
@@ -91,14 +92,14 @@ Flags:
   -o, --output string                       Styling for output format. json, json-pretty, text, csv (default "text")
 
 Global Flags:
-  -v, -- count            Set log level, multiple v's is more verbose
-      --loud              indicate output should include non-vulnerable packages
-  -p, --path string       Specify a path to a dep Gopkg.lock file for scanning
-  -q, --quiet             indicate output should contain only packages with vulnerabilities (default true)
-  -t, --token string      Specify OSS Index API token for request
-  -u, --username string   Specify OSS Index username for request
-  -V, --version           Get the version
-
+  -v, -- count              Set log level, multiple v's is more verbose
+      --loud                indicate output should include non-vulnerable packages
+  -p, --path string         Specify a path to a dep Gopkg.lock file for scanning
+  -q, --quiet               indicate output should contain only packages with vulnerabilities (default true)
+      --skip-update-check   Skip the check for updates.
+  -t, --token string        Specify OSS Index API token for request
+  -u, --username string     Specify OSS Index username for request
+  -V, --version             Get the version
 
 $ > nancy iq --help
 'nancy iq' is a command to check for vulnerabilities in your Golang dependencies, powered by 'Sonatype's Nexus IQ IQServer', allowing you a smooth experience as a Golang developer, using the best tools in the market!
@@ -119,13 +120,14 @@ Flags:
   -l, --iq-username string      Specify Nexus IQ username for request (default "admin")
 
 Global Flags:
-  -v, -- count            Set log level, multiple v's is more verbose
-      --loud              indicate output should include non-vulnerable packages
-  -p, --path string       Specify a path to a dep Gopkg.lock file for scanning
-  -q, --quiet             indicate output should contain only packages with vulnerabilities (default true)
-  -t, --token string      Specify OSS Index API token for request
-  -u, --username string   Specify OSS Index username for request
-  -V, --version           Get the version
+  -v, -- count              Set log level, multiple v's is more verbose
+      --loud                indicate output should include non-vulnerable packages
+  -p, --path string         Specify a path to a dep Gopkg.lock file for scanning
+  -q, --quiet               indicate output should contain only packages with vulnerabilities (default true)
+      --skip-update-check   Skip the check for updates.
+  -t, --token string        Specify OSS Index API token for request
+  -u, --username string     Specify OSS Index username for request
+  -V, --version             Get the version
 ```
 
 #### What is the best usage of Nancy?

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sdboyer/constext v0.0.0-20170321163424-836a14457353 // indirect
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.6.0
-	github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210195643-1bba8f78e485
+	github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210200544-9df2e856d2bf
 	github.com/spf13/afero v1.3.4 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sdboyer/constext v0.0.0-20170321163424-836a14457353 // indirect
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.6.0
-	github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210164431-51e967556b00
+	github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210195643-1bba8f78e485
 	github.com/spf13/afero v1.3.4 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sdboyer/constext v0.0.0-20170321163424-836a14457353 // indirect
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.6.0
-	github.com/sonatype-nexus-community/go-sona-types v0.0.10
+	github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210164431-51e967556b00
 	github.com/spf13/afero v1.3.4 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sdboyer/constext v0.0.0-20170321163424-836a14457353 // indirect
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.6.0
-	github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210200544-9df2e856d2bf
+	github.com/sonatype-nexus-community/go-sona-types v0.0.11
 	github.com/spf13/afero v1.3.4 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
-github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210200544-9df2e856d2bf h1:q0+fd9kLZsJgwUJRWwyCXkw7ztEiyid0EPfgS9Xdn34=
-github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210200544-9df2e856d2bf/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
+github.com/sonatype-nexus-community/go-sona-types v0.0.11 h1:OXdS+oFXr/g3ye+DiW2SkwIFrZ/ONdDv+YvW0AuTGeo=
+github.com/sonatype-nexus-community/go-sona-types v0.0.11/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.3.4 h1:8q6vk3hthlpb2SouZcnBVKboxWQWMDNF38bwholZrJc=

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
-github.com/sonatype-nexus-community/go-sona-types v0.0.10 h1:VW+OE1vAjBwwRCz7jz4xcBbUn1j3bz1gFnEw1YYmYGs=
-github.com/sonatype-nexus-community/go-sona-types v0.0.10/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
+github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210164431-51e967556b00 h1:auDsEIVyX0T8tQFIB77LeTE+A3uE1GMg9VcclYNNocY=
+github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210164431-51e967556b00/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.3.4 h1:8q6vk3hthlpb2SouZcnBVKboxWQWMDNF38bwholZrJc=

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
-github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210164431-51e967556b00 h1:auDsEIVyX0T8tQFIB77LeTE+A3uE1GMg9VcclYNNocY=
-github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210164431-51e967556b00/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
+github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210195643-1bba8f78e485 h1:zqPSQcPC0+mfXZNtMqfhkatfVjiSgUs9foOI9ZuDbjI=
+github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210195643-1bba8f78e485/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.3.4 h1:8q6vk3hthlpb2SouZcnBVKboxWQWMDNF38bwholZrJc=

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
-github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210195643-1bba8f78e485 h1:zqPSQcPC0+mfXZNtMqfhkatfVjiSgUs9foOI9ZuDbjI=
-github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210195643-1bba8f78e485/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
+github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210200544-9df2e856d2bf h1:q0+fd9kLZsJgwUJRWwyCXkw7ztEiyid0EPfgS9Xdn34=
+github.com/sonatype-nexus-community/go-sona-types v0.0.11-0.20210210200544-9df2e856d2bf/go.mod h1:uou8FGf9R5Nz1c6BfSM3v9K7g0R6faTYoxLh9Ybeht8=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.3.4 h1:8q6vk3hthlpb2SouZcnBVKboxWQWMDNF38bwholZrJc=

--- a/internal/cmd/check.go
+++ b/internal/cmd/check.go
@@ -27,6 +27,11 @@ import (
 
 // For use in checking for newer release version during app startup (not during explicit command to check for update)
 func checkForUpdates(gitHubAPI string) error {
+	if configOssi.SkipUpdateCheck {
+		logLady.Debug("skipping update check")
+		return nil
+	}
+
 	updateCheck := &settings.UpdateCheck{
 		LastUpdateCheck: time.Time{},
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -170,14 +170,16 @@ const (
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().CountVarP(&configOssi.LogLevel, "", "v", "Set log level, multiple v's is more verbose")
-	rootCmd.PersistentFlags().BoolVarP(&configOssi.Version, "version", "V", false, "Get the version")
-	rootCmd.PersistentFlags().BoolVarP(&configOssi.Quiet, "quiet", "q", true, "indicate output should contain only packages with vulnerabilities")
-	rootCmd.PersistentFlags().BoolVar(&configOssi.Loud, "loud", false, "indicate output should include non-vulnerable packages")
+	persistentFlags := rootCmd.PersistentFlags()
+	persistentFlags.CountVarP(&configOssi.LogLevel, "", "v", "Set log level, multiple v's is more verbose")
+	persistentFlags.BoolVarP(&configOssi.Version, "version", "V", false, "Get the version")
+	persistentFlags.BoolVarP(&configOssi.Quiet, "quiet", "q", true, "indicate output should contain only packages with vulnerabilities")
+	persistentFlags.BoolVar(&configOssi.Loud, "loud", false, "indicate output should include non-vulnerable packages")
 	rootCmd.Flags().BoolVarP(&configOssi.CleanCache, "clean-cache", "c", false, "Deletes local cache directory")
-	rootCmd.PersistentFlags().StringVarP(&configOssi.Username, flagNameOssiUsername, "u", "", "Specify OSS Index username for request")
-	rootCmd.PersistentFlags().StringVarP(&configOssi.Token, flagNameOssiToken, "t", "", "Specify OSS Index API token for request")
-	rootCmd.PersistentFlags().StringVarP(&configOssi.Path, "path", "p", "", "Specify a path to a dep "+GopkgLockFilename+" file for scanning")
+	persistentFlags.StringVarP(&configOssi.Username, flagNameOssiUsername, "u", "", "Specify OSS Index username for request")
+	persistentFlags.StringVarP(&configOssi.Token, flagNameOssiToken, "t", "", "Specify OSS Index API token for request")
+	persistentFlags.StringVarP(&configOssi.Path, "path", "p", "", "Specify a path to a dep "+GopkgLockFilename+" file for scanning")
+	persistentFlags.BoolVar(&configOssi.SkipUpdateCheck, "skip-update-check", configuration.SkipUpdateByDefault(), "Skip the check for updates.")
 }
 
 func bindViperRootCmd() {

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -313,6 +313,10 @@ func TestConfigOssi_cleanCache(t *testing.T) {
 	validateConfigOssi(t, types.Configuration{CleanCache: true}, []string{"--clean-cache"}...)
 }
 
+func TestConfigOssi_skip_update_check(t *testing.T) {
+	validateConfigOssi(t, types.Configuration{SkipUpdateCheck: true}, []string{"--skip-update-check"}...)
+}
+
 func setupConfig(t *testing.T) (tempDir string) {
 	tempDir, err := ioutil.TempDir("", "config-test")
 	assert.NoError(t, err)

--- a/types/types.go
+++ b/types/types.go
@@ -39,24 +39,25 @@ type GoListModule struct {
 }
 
 type Configuration struct {
-	Version       bool
-	NoColor       bool
-	Quiet         bool
-	Loud          bool
-	CleanCache    bool
-	CveList       CveListFlag
-	Path          string
-	Formatter     logrus.Formatter
-	LogLevel      int
-	Username      string
-	Token         string
-	Help          bool
-	IQUsername    string
-	IQToken       string
-	IQStage       string
-	IQApplication string
-	IQServer      string
-	MaxRetries    int
+	Version         bool
+	NoColor         bool
+	Quiet           bool
+	Loud            bool
+	CleanCache      bool
+	CveList         CveListFlag
+	Path            string
+	Formatter       logrus.Formatter
+	LogLevel        int
+	Username        string
+	Token           string
+	Help            bool
+	IQUsername      string
+	IQToken         string
+	IQStage         string
+	IQApplication   string
+	IQServer        string
+	MaxRetries      int
+	SkipUpdateCheck bool
 }
 
 type Projects struct {


### PR DESCRIPTION
If nancy detects she is running in a CI environment or the `SKIP_UPDATE_CHECK` environment variable is set, the automatic check for an update will be skipped.

Also adds the `--skip-update-check` command line flag to never check for an update, no matter what.

It relates to the following issue #s:
* Fixes #217

cc @bhamail / @DarthHater
