### PR TITLE
Add a non-versioned "latest" artifact

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -99,7 +99,7 @@ dockers:
     goarch: amd64
     dockerfile: build/Dockerfile.alpine
     binaries:
-    - nancy
+      - nancy
     build_flag_templates:
     - "--pull"
     - "--label=author='DJ Schleen'"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,7 +83,7 @@ dockers:
     goos: linux
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
-    binaries:
+    ids:
       - nancy
     build_flag_templates:
     - "--label=author='DJ Schleen'"
@@ -98,7 +98,7 @@ dockers:
     goos: linux
     goarch: amd64
     dockerfile: build/Dockerfile.alpine
-    binaries:
+    ids:
       - nancy
     build_flag_templates:
     - "--pull"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,10 @@ archives:
     name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: binary
   -
+    id: latest
+    name_template: "{{ .ProjectName }}-latest-{{ .Os }}-{{ .Arch }}"
+    format: binary
+  -
     id: homebrew
     name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format_overrides:
@@ -62,6 +66,7 @@ changelog:
 release:
   ids:
     - default
+    - latest
     - homebrew
   github:
     owner: sonatype-nexus-community


### PR DESCRIPTION
There are a number of use cases enabled by producing a "non-versioned" (aka "latest") binary when releasing. This PR adds such binaries (I think...).

It relates to the following issue #s:
* Fixes #47

cc @bhamail / @DarthHater
