### PR TITLE
Config via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,15 @@ You can also set the user and token via the command line like so:
 
 This can be handy for testing your account out, or if you want to override your set config with a different user.
 
+As of Nancy v1.0.17, you can also specify configuration values using environment variables:
+
+```shell
+export OSSI_USERNAME=auser@anemailaddress.com
+export OSSI_TOKEN=A4@k3@p1T0k3n
+go list -json -m all | ./nancy sleuth
+...
+```
+
 #### Loud mode
 
 By default, `nancy` runs in a "quiet" mode, only displaying a list of vulnerable components.
@@ -493,6 +502,18 @@ To set your Nexus IQ Server config run:
 `nancy config`
 
 Choose `iq` as an option and run through the rest of the config. Once you are done, Nancy should use this config for communicating with Nexus IQ, simplifying your use of the tool.
+
+As of Nancy v1.0.17, you can also specify configuration values using environment variables:
+
+```shell
+export OSSI_USERNAME=auser@anemailaddress.com
+export OSSI_TOKEN=A4@k3@p1T0k3n
+export IQ_USERNAME=nondefaultuser
+export IQ_TOKEN=yourtoken
+export IQ_SERVER=http://adifferentserverurl:port
+go list -json -m all | ./nancy iq --iq-application public-application-id
+...
+```
 
 ### Usage in CI
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -116,6 +116,11 @@ var rootCmd = &cobra.Command{
 powered by the 'Sonatype OSS Index', and as well, works with Nexus IQ Server, allowing you
 a smooth experience as a Golang developer, using the best tools in the market!`,
 	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+		viper.AutomaticEnv()
+		//Substitute the _ to .
+		replacer := strings.NewReplacer(".", "_")
+		viper.SetEnvKeyReplacer(replacer)
+
 		logLady = logger.GetLogger("", configOssi.LogLevel)
 		return checkForUpdates("")
 	},

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -100,6 +100,15 @@ var (
 	stdInInvalid                                   = fmt.Errorf("StdIn is invalid or empty. Did you forget to pipe 'go list' to nancy?")
 )
 
+//Substitute the _ to .
+var viperKeyReplacer = strings.NewReplacer(".", "_")
+
+func setupViperAutomaticEnv() {
+	viper.AutomaticEnv()
+	//Substitute the _ to .
+	viper.SetEnvKeyReplacer(viperKeyReplacer)
+}
+
 var rootCmd = &cobra.Command{
 	Version: buildversion.BuildVersion,
 	Use:     "nancy",
@@ -116,11 +125,7 @@ var rootCmd = &cobra.Command{
 powered by the 'Sonatype OSS Index', and as well, works with Nexus IQ Server, allowing you
 a smooth experience as a Golang developer, using the best tools in the market!`,
 	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-		viper.AutomaticEnv()
-		//Substitute the _ to .
-		replacer := strings.NewReplacer(".", "_")
-		viper.SetEnvKeyReplacer(replacer)
-
+		setupViperAutomaticEnv()
 		logLady = logger.GetLogger("", configOssi.LogLevel)
 		return checkForUpdates("")
 	},

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -525,3 +525,8 @@ func TestCleanUserName(t *testing.T) {
 	assert.Equal(t, "1***hidden***1", cleanUserName("1"))
 	assert.Equal(t, "1***hidden***2", cleanUserName("12"))
 }
+
+func TestViperKeyNameReplacer(t *testing.T) {
+	envVarName := viperKeyReplacer.Replace(configuration.ViperKeyUsername)
+	assert.Equal(t, "ossi_Username", envVarName)
+}


### PR DESCRIPTION
Flip the switches required to make Viper read environment variables for configuration values.

cc @bhamail / @DarthHater
