### PR TITLE
do not publish Dockerfile.alpine image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,22 +95,6 @@ dockers:
     - "sonatypecommunity/nancy:{{ .Tag }}"
     - "sonatypecommunity/nancy:v{{ .Major }}"
     - "sonatypecommunity/nancy:v{{ .Major }}.{{ .Minor }}"
-  -
-    goos: linux
-    goarch: amd64
-    dockerfile: build/Dockerfile.alpine
-    ids:
-      - nancy
-    build_flag_templates:
-    - "--pull"
-    - "--label=author='DJ Schleen'"
-    - "--label=version={{ .Version }}"
-    - "--label=maintainer='sonatype-nexus-community'"
-    image_templates:
-    - "sonatypecommunity/nancy:alpine"
-    - "sonatypecommunity/nancy:{{ .Tag }}-alpine"
-    - "sonatypecommunity/nancy:v{{ .Major }}-alpine"
-    - "sonatypecommunity/nancy:v{{ .Major }}.{{ .Minor }}-alpine"
 
 nfpms:
   -


### PR DESCRIPTION
Not sure why, but after making an unrelated change to `goreleaser.yml` (for Issue #229), the `goreleaser` call is failing (both locally and on CircleCI) when trying to create the second alpine docker image for publishing:

```shell
$ goreleaser  --snapshot --skip-publish --rm-dist
...
   • docker images    
      • building docker image     buildx=false image=sonatypecommunity/nancy:latest
   ⨯ release failed after 9.54s error=failed to link dockerfile: link build/Dockerfile.alpine dist/goreleaserdocker055539225/Dockerfile: no such file or directory
```

[CircleCI failure](https://app.circleci.com/pipelines/github/sonatype-nexus-community/nancy/807/workflows/446d8eac-8dc5-41a7-bf7e-203d73d6c9ca/jobs/825) 

After banging my head on a wall trying to solve this build failure (with no success), I'm wondering if we should just stop publishing the failing docker image (from [Dockerfile.alpine](https://github.com/sonatype-nexus-community/nancy/blob/main/Dockerfile.alpine))?

Both the successful docker image (from [Dockerfile.goreleaser](https://github.com/sonatype-nexus-community/nancy/blob/main/Dockerfile.goreleaser)) and the failing docker image (from [Dockerfile.alpine](https://github.com/sonatype-nexus-community/nancy/blob/main/Dockerfile.alpine)) are `alpine` based images. The successful image is "from scratch", and is much smaller.

Any objection to changing the build to only publish the docker image built from `Dockerfile.goreleaser`?

WAIT, STOP, I think there is a different problem causing this - will likely delete this PR when things a clearer

cc @bhamail / @DarthHater
