### PR TITLE
Add new sarif formatter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/nightlyone/lockfile v1.0.0 // indirect
+	github.com/owenrumney/go-sarif v1.0.4
 	github.com/pelletier/go-toml v1.8.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/rhysd/go-github-selfupdate v1.2.3
@@ -31,7 +32,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.7.0
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/ini.v1 v1.60.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ github.com/Masterminds/vcs v1.13.1/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHS
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -83,6 +84,7 @@ github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFU
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
@@ -199,6 +201,8 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.2 h1:3mYCb7aPxS/RU7TI1y4rkEn1oKmPRjNJLNEXgw7MH2I=
 github.com/onsi/gomega v1.4.2/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/owenrumney/go-sarif v1.0.4 h1:0LFC5eHP6amc/9ajM1jDiE52UfXFcl/oozay+X3KgV4=
+github.com/owenrumney/go-sarif v1.0.4/go.mod h1:DXUGbHwQcCMvqcvZbxh8l/7diHsJVztOKZgmPt88RNI=
 github.com/package-url/packageurl-go v0.1.0 h1:efWBc98O/dBZRg1pw2xiDzovnlMjCa9NPnfaiBduh8I=
 github.com/package-url/packageurl-go v0.1.0/go.mod h1:C/ApiuWpmbpni4DIOECf6WCjFUZV7O1Fx7VAzrZHgBw=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -272,8 +276,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tcnksm/go-gitconfig v0.1.2 h1:iiDhRitByXAEyjgBqsKi9QU4o2TNtv9kPP3RgPgXBPw=
@@ -282,8 +286,12 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ulikunitz/xz v0.5.9 h1:RsKRIA2MO8x56wkkcd3LbtcE/uMszhb6DpRf+3uwa3I=
 github.com/ulikunitz/xz v0.5.9/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
+github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/zclconf/go-cty v1.8.2 h1:u+xZfBKgpycDnTNjPhGiTEYZS5qS/Sb5MqSfm7vzcjg=
+github.com/zclconf/go-cty v1.8.2/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -331,8 +339,9 @@ golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
-golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -399,8 +408,9 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
-google.golang.org/appengine v1.6.1 h1:QzqyMA1tlu6CgqCDUtU9V+ZKhLFT2dkJuANu5QaxI3I=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
+google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
+google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/internal/audit/sarifformatter.go
+++ b/internal/audit/sarifformatter.go
@@ -1,0 +1,150 @@
+//
+// Copyright 2018-present Sonatype Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package audit
+
+import (
+	"bytes"
+	"strings"
+	"text/template"
+
+	"github.com/owenrumney/go-sarif/sarif"
+	"github.com/shopspring/decimal"
+	. "github.com/sirupsen/logrus"
+	"github.com/sonatype-nexus-community/go-sona-types/ossindex/types"
+)
+
+type SarifFormatter struct {
+	UsingDep bool
+}
+
+func (f SarifFormatter) Format(entry *Entry) ([]byte, error) {
+	auditedEntries := entry.Data["audited"].([]types.Coordinate)
+	invalidEntries := entry.Data["invalid"].([]types.Coordinate)
+	buildVersion := entry.Data["version"].(string)
+
+	report, err := sarif.New(sarif.Version210)
+	if err != nil {
+		return nil, err
+	}
+	run := sarif.NewRun("nancy", "https://ossindex.sonatype.org/integration/nancy")
+	run.Tool.Driver.WithVersion(buildVersion)
+	report.AddRun(run)
+
+	buildSarifForAuditedEntries(f.UsingDep, auditedEntries, run)
+	buildSarifForInvalidEntries(f.UsingDep, invalidEntries, run)
+
+	var buff bytes.Buffer
+	err = report.PrettyWrite(&buff)
+	if err != nil {
+		return nil, err
+	}
+	return buff.Bytes(), nil
+}
+
+const invalidCoordinateId = "InvalidCoordinate"
+
+func buildSarifForInvalidEntries(usingDep bool, invalidEntries []types.Coordinate, run *sarif.Run) {
+	for _, coordinate := range invalidEntries {
+		rule := run.AddRule(invalidCoordinateId).
+			WithDescription("Scanning cannot be completed on the following package(s) since they do not use semver.")
+
+		message := sarif.NewMessage().WithText(convertToGoModSyntax(coordinate.Coordinates))
+
+		ruleResult := run.AddResult(rule.ID)
+
+		artifactLocation := determineLocation(usingDep)
+		fingerPrints := map[string]interface{}{
+			"sonatypeId": invalidCoordinateId,
+			"coordinate": coordinate.Coordinates,
+		}
+		ruleResult.
+			WithLocation(sarif.NewLocation().
+				WithPhysicalLocation(sarif.NewPhysicalLocation().
+					WithArtifactLocation(artifactLocation).
+					WithRegion(sarif.NewRegion().WithStartLine(1))),
+			).
+			WithPartialFingerPrints(fingerPrints).
+			WithLevel("note").WithMessage(message)
+	}
+}
+
+func determineLocation(dep bool) *sarif.ArtifactLocation {
+	artifactLocation := sarif.NewArtifactLocation().WithUri("go.mod")
+	if dep == true {
+		artifactLocation = sarif.NewArtifactLocation().WithUri("Gopkg.lock")
+	}
+	return artifactLocation
+}
+
+func buildSarifForAuditedEntries(usingDep bool, auditedEntries []types.Coordinate, run *sarif.Run) {
+	for _, coordinate := range auditedEntries {
+		if coordinate.IsVulnerable() {
+			for _, vuln := range coordinate.Vulnerabilities {
+				data := map[string]interface{}{
+					"Score":            vuln.CvssScore,
+					"SonatypeSeverity": scoreAssessment(vuln.CvssScore),
+					"URL":              vuln.Reference,
+				}
+				var ruleHelpMarkdown bytes.Buffer
+				tmpl, _ := template.New("test").Parse(`
+CVSS Score of **{{.Score}} ({{.SonatypeSeverity}})**
+Find more details here: 
+{{.URL}}`)
+				tmpl.Execute(&ruleHelpMarkdown, data)
+				var ruleHelpText = vuln.Cve + " " + vuln.Description + " " + vuln.Reference
+
+				rule := run.AddRule(vuln.ID).
+					WithDescription(vuln.Title).
+					WithFullDescription(sarif.NewMultiformatMessageString(vuln.Description))
+
+				rule.Help = sarif.NewMultiformatMessageString(ruleHelpText).WithMarkdown(ruleHelpMarkdown.String())
+
+				message := sarif.NewMessage().WithText(convertToGoModSyntax(coordinate.Coordinates))
+				level := sarifScoreAssessment(vuln.CvssScore)
+
+				ruleResult := run.AddResult(rule.ID)
+
+				artifactLocation := determineLocation(usingDep)
+				fingerPrints := map[string]interface{}{
+					"sonatypeId": vuln.ID,
+					"coordinate": coordinate.Coordinates,
+				}
+				ruleResult.
+					WithLocation(sarif.NewLocation().
+						WithPhysicalLocation(sarif.NewPhysicalLocation().
+							WithArtifactLocation(artifactLocation).
+							WithRegion(sarif.NewRegion().WithStartLine(1))),
+					).
+					WithPartialFingerPrints(fingerPrints).
+					WithLevel(level).WithMessage(message)
+			}
+		}
+	}
+}
+
+func convertToGoModSyntax(coordinate string) string{
+	gomodCoor := strings.ReplaceAll(coordinate, "pkg:golang/", "")
+	gomodCoor = strings.ReplaceAll(gomodCoor, "@", " ")
+	return gomodCoor
+}
+
+func sarifScoreAssessment(score decimal.Decimal) string {
+	if score.GreaterThanOrEqual(seven) {
+		return "error"
+	}
+	return "warning"
+}

--- a/internal/audit/sarifformatter.go
+++ b/internal/audit/sarifformatter.go
@@ -84,7 +84,7 @@ func buildSarifForInvalidEntries(usingDep bool, invalidEntries []types.Coordinat
 
 func determineLocation(dep bool) *sarif.ArtifactLocation {
 	artifactLocation := sarif.NewArtifactLocation().WithUri("go.mod")
-	if dep == true {
+	if dep {
 		artifactLocation = sarif.NewArtifactLocation().WithUri("Gopkg.lock")
 	}
 	return artifactLocation
@@ -104,7 +104,7 @@ func buildSarifForAuditedEntries(usingDep bool, auditedEntries []types.Coordinat
 CVSS Score of **{{.Score}} ({{.SonatypeSeverity}})**
 Find more details here: 
 {{.URL}}`)
-				tmpl.Execute(&ruleHelpMarkdown, data)
+				_ = tmpl.Execute(&ruleHelpMarkdown, data)
 				var ruleHelpText = vuln.Cve + " " + vuln.Description + " " + vuln.Reference
 
 				rule := run.AddRule(vuln.ID).

--- a/internal/audit/sarifformatter_test.go
+++ b/internal/audit/sarifformatter_test.go
@@ -1,0 +1,116 @@
+//
+// Copyright 2018-present Sonatype Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package audit
+
+import (
+	"testing"
+
+	. "github.com/sirupsen/logrus"
+	"github.com/sonatype-nexus-community/go-sona-types/ossindex/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSarifOutput(t *testing.T) {
+	data := map[string]interface{}{
+		"audited": []types.Coordinate{
+			{Coordinates: "good1"},
+			{Coordinates: "pkg:golang/vuln1@1.0.0", Vulnerabilities: createVulnerabilities(1)},
+		},
+		"invalid": []types.Coordinate{},
+		"num_audited":    2,
+		"num_vulnerable": 1,
+		"version":        "development",
+	}
+	entry := Entry{Data: data}
+
+	formatter := SarifFormatter{}
+	logMessage, e := formatter.Format(&entry)
+
+	assert.Nil(t, e)
+	actual := string(logMessage)
+	assert.Equal(t, `{
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "nancy",
+          "version": "development",
+          "informationUri": "https://ossindex.sonatype.org/integration/nancy",
+          "rules": [
+            {
+              "id": "123",
+              "shortDescription": {
+                "text": "Vulnerability"
+              },
+              "fullDescription": {
+                "text": "Description"
+              },
+              "help": {
+                "text": "CVE-123 Description Reference",
+                "markdown": "\nCVSS Score of **7.88 (High)**\nFind more details here: \nReference"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "123",
+          "level": "error",
+          "message": {
+            "text": "vuln1 1.0.0"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "go.mod"
+                },
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "coordinate": "pkg:golang/vuln1@1.0.0",
+            "sonatypeId": "123"
+          }
+        }
+      ]
+    }
+  ]
+}`, actual)
+}
+
+func TestSarifOutputWhenDep(t *testing.T) {
+	t.Fail()
+}
+
+func TestSerifOutputWithWarningsLevelVulns(t *testing.T) {
+	t.Fail()
+}
+
+func TestSerifOutputWithInvalidEntries(t *testing.T) {
+	t.Fail()
+}
+
+func TestSerifOutputWithMultipleVulnerabilities(t *testing.T) {
+	t.Fail()
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -257,6 +257,8 @@ func processConfig() (err error) {
 		configOssi.Formatter = audit.AuditLogTextFormatter{Quiet: isQuiet, NoColor: configOssi.NoColor}
 	case "json":
 		configOssi.Formatter = audit.JsonFormatter{}
+	case "sarif":
+		configOssi.Formatter = audit.SarifFormatter{UsingDep: configOssi.Path != ""}
 	case "json-pretty":
 		configOssi.Formatter = audit.JsonFormatter{PrettyPrint: true}
 	case "csv":

--- a/internal/cmd/sleuth.go
+++ b/internal/cmd/sleuth.go
@@ -31,7 +31,7 @@ func init() {
 	sleuthCmd.Flags().BoolVarP(&configOssi.NoColor, "no-color", "n", false, "indicate output should not be colorized")
 	sleuthCmd.Flags().VarP(&configOssi.CveList, "exclude-vulnerability", "e", "Comma separated list of CVEs or OSS Index IDs to exclude")
 	sleuthCmd.Flags().StringVarP(&excludeVulnerabilityFilePath, "exclude-vulnerability-file", "x", defaultExcludeFilePath, "Path to a file containing newline separated CVEs or OSS Index IDs to be excluded")
-	sleuthCmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Styling for output format. json, json-pretty, text, csv")
+	sleuthCmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Styling for output format. json, json-pretty, text, csv, sarif")
 }
 
 var sleuthCmd = &cobra.Command{


### PR DESCRIPTION
Working through adding what is needed to do #239. 

This pull request makes the following changes:
* Adds a new formatter... thats it nothing to crazy

It relates to the following issue #s:
* Fixes #239

cc @bhamail / @DarthHater

-------------------

## How im testing this?
Currently using the https://github.com/sonatype-nexus-community/intentionally-vulnerable-golang-project project. And running my local build against nancy with the `-o sarif` output option and then dumping to a file and doing some magic incantations necessary for github to be happy. (the action will take care of this later) 

```
go list -json -m all | ../nancy/nancy sleuth -o sarif > analysis-data.sarif
gzip -c analysis-data.sarif | base64 |tr -d '\n' | pbcopy
```

And then this curl command to send the results to my forked repo above

```
curl --location --request POST 'https://api.github.com/repos/zendern/intentionally-vulnerable-golang-project/code-scanning/sarifs' \
--header 'Accept: application/vnd.github.v3+json' \
--header 'Authorization: token <your github token>' \
--header 'Content-Type: application/json' \
--data-raw '{
"tool_name": "Sonatype Nancy",
"commit_sha": "d027c0472f6ef91aa9ce50674536c2787ca9863b",
"ref": "refs/heads/master",
"sarif": "<paste in big chunk of sarif here>"
}'
```

If you want to stitch the above together to check it out on your own repo you should be able to by changing the url in the curl above. 

----------------------

## So whats it look like??

So you can poke around here. 

https://github.com/zendern/intentionally-vulnerable-golang-project/security/code-scanning?query=tool%3Anancy

### List screen
Github alert types can only be of one of the 4 types. [none, note, warning and error]. I have implemented it as follows : 

* CVSS score > 7 == error (Critical and High)
* Anything less than that == warning (Medium and Low)

Following the lead here

https://github.com/sonatype-nexus-community/nancy/blob/30fb76a3ebf93a41d391d4cacff9d8154ca3fd5d/internal/audit/auditlogtextformatter.go#L124-L135

**Outstanding question on this would be should Low == Note as far as github code scanning goes or does Warning still make sense to use??** 

![screencapture-github-zendern-intentionally-vulnerable-golang-project-security-code-scanning-2021-06-06-23_10_00](https://user-images.githubusercontent.com/1099906/120954075-60160680-c71c-11eb-8cb1-5d67a5f784de.png)

### Vulnerability details page

![screencapture-github-zendern-intentionally-vulnerable-golang-project-security-code-scanning-22-2021-06-06-23_10_18](https://user-images.githubusercontent.com/1099906/120954079-62786080-c71c-11eb-9945-1697a5a97fe6.png)

Looks wise we can probably maybe do better. Markdown support is available in some fields but does have the caveat of once you throw a newline in there Github collapses it and will make you expand before you get them sweet sweet details. 

Also something to note since we do not have full (is transitive deps/actually in go.mod/Gopkg.lock file) I am just pinning the line number of the issue to the first line in the corresponding go.mod/Gopkg.lock file to indicate its a dependency issue. Does this seem reasonable??

## What's left outstanding?

- [ ] Implement the stubbed out tests
- [ ] Determine if levels are setup appropriately for CVVS Score -> Github Severity 
- [ ] Probably some formatting
- [ ] Test it out using github action 