### PR TITLE
fixes #241 - add maintainer field

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -115,6 +115,7 @@ dockers:
 nfpms:
   -
     vendor: sonatype-nexus-community
+    maintainer: Sonatype Nexus Community <community-group@sonatype.com>
     homepage: https://github.com/sonatype-nexus-community/nancy
     description: "A tool to check for vulnerabilities in your Golang dependencies, powered by Sonatype OSS Index"
     formats:


### PR DESCRIPTION
add maintainer field to quiet warnings from dpkg/apt about its absence.

It relates to the following issue #s:
* Fixes #241

cc @bhamail / @DarthHater
