### PR TITLE
show number of ignored vulnerabilities in summary table

### DIFF
--- a/internal/audit/auditlog.go
+++ b/internal/audit/auditlog.go
@@ -28,6 +28,7 @@ import (
 // results.
 func LogResults(formatter log.Formatter, packageCount int, coordinates []types.Coordinate, invalidCoordinates []types.Coordinate, exclusions []string) int {
 	vulnerableCount := 0
+	exclusionCount := 0
 
 	for _, c := range coordinates {
 		c.ExcludeVulnerabilities(exclusions)
@@ -35,9 +36,16 @@ func LogResults(formatter log.Formatter, packageCount int, coordinates []types.C
 
 	var auditedCoordinates []types.Coordinate
 	var vulnerableCoordinates []types.Coordinate
+	var excludedVulnerabilities []types.Vulnerability
 
 	for i := 0; i < len(coordinates); i++ {
 		coordinate := coordinates[i]
+		for _, v := range coordinate.Vulnerabilities {
+			if v.Excluded {
+				exclusionCount++
+				excludedVulnerabilities = append(excludedVulnerabilities, v)
+			}
+		}
 		if coordinate.IsVulnerable() {
 			vulnerableCount++
 			vulnerableCoordinates = append(vulnerableCoordinates, coordinate)
@@ -54,14 +62,17 @@ func LogResults(formatter log.Formatter, packageCount int, coordinates []types.C
 	if vulnerableCoordinates == nil {
 		vulnerableCoordinates = make([]types.Coordinate, 0)
 	}
+
 	log.SetFormatter(formatter)
 	log.SetOutput(os.Stdout)
 	log.WithFields(log.Fields{
 		"exclusions":     exclusions,
 		"num_audited":    packageCount,
 		"num_vulnerable": vulnerableCount,
+		"num_exclusions": exclusionCount,
 		"audited":        auditedCoordinates,
 		"vulnerable":     vulnerableCoordinates,
+		"excluded":       excludedVulnerabilities,
 		"invalid":        invalidCoordinates,
 		"version":        buildversion.BuildVersion,
 	}).Info("")

--- a/internal/audit/auditlogtextformatter.go
+++ b/internal/audit/auditlogtextformatter.go
@@ -153,14 +153,17 @@ func groupAndPrint(vulnerable []types.Coordinate, nonVulnerable []types.Coordina
 func (f AuditLogTextFormatter) Format(entry *Entry) ([]byte, error) {
 	auditedEntries := entry.Data["audited"]
 	invalidEntries := entry.Data["invalid"]
+	excludedEntries := entry.Data["excluded"]
 	packageCount := entry.Data["num_audited"]
 	numVulnerable := entry.Data["num_vulnerable"]
+	numExcluded := entry.Data["num_exclusions"]
 	buildVersion := entry.Data["version"]
-	if auditedEntries != nil && invalidEntries != nil && packageCount != nil && numVulnerable != nil && buildVersion != nil {
+	if auditedEntries != nil && invalidEntries != nil && excludedEntries != nil && packageCount != nil && numVulnerable != nil && numExcluded != nil && buildVersion != nil {
 		auditedEntries := entry.Data["audited"].([]types.Coordinate)
 		invalidEntries := entry.Data["invalid"].([]types.Coordinate)
 		packageCount := entry.Data["num_audited"].(int)
 		numVulnerable := entry.Data["num_vulnerable"].(int)
+		numExcluded := entry.Data["num_exclusions"].(int)
 
 		var sb strings.Builder
 
@@ -179,6 +182,8 @@ func (f AuditLogTextFormatter) Format(entry *Entry) ([]byte, error) {
 		t.AppendRow([]interface{}{"Audited Dependencies", strconv.Itoa(packageCount)})
 		t.AppendSeparator()
 		t.AppendRow([]interface{}{"Vulnerable Dependencies", au.Bold(au.Red(strconv.Itoa(numVulnerable)))})
+		t.AppendSeparator()
+		t.AppendRow([]interface{}{"Ignored Vulnerabilities", au.Bold(au.Yellow(strconv.Itoa(numExcluded)))})
 		sb.WriteString(t.Render())
 		sb.WriteString("\n")
 

--- a/internal/audit/auditlogtextformatter.go
+++ b/internal/audit/auditlogtextformatter.go
@@ -182,8 +182,10 @@ func (f AuditLogTextFormatter) Format(entry *Entry) ([]byte, error) {
 		t.AppendRow([]interface{}{"Audited Dependencies", strconv.Itoa(packageCount)})
 		t.AppendSeparator()
 		t.AppendRow([]interface{}{"Vulnerable Dependencies", au.Bold(au.Red(strconv.Itoa(numVulnerable)))})
-		t.AppendSeparator()
-		t.AppendRow([]interface{}{"Ignored Vulnerabilities", au.Bold(au.Yellow(strconv.Itoa(numExcluded)))})
+    if numExcluded > 0 {
+      t.AppendSeparator()
+      t.AppendRow([]interface{}{"Ignored Vulnerabilities", au.Bold(au.Yellow(strconv.Itoa(numExcluded)))})
+    }
 		sb.WriteString(t.Render())
 		sb.WriteString("\n")
 

--- a/internal/audit/csvformatter.go
+++ b/internal/audit/csvformatter.go
@@ -41,19 +41,21 @@ func (f CsvFormatter) Format(entry *Entry) ([]byte, error) {
 	invalidEntries := entry.Data["invalid"]
 	packageCount := entry.Data["num_audited"]
 	numVulnerable := entry.Data["num_vulnerable"]
+	excludedCount := entry.Data["num_exclusions"]
 	buildVersion := entry.Data["version"]
 
-	if auditedEntries != nil && invalidEntries != nil && packageCount != nil && numVulnerable != nil && buildVersion != nil {
+	if auditedEntries != nil && invalidEntries != nil && packageCount != nil && numVulnerable != nil && excludedCount != nil && buildVersion != nil {
 		auditedEntries := entry.Data["audited"].([]types.Coordinate)
 		invalidEntries := entry.Data["invalid"].([]types.Coordinate)
 		packageCount := entry.Data["num_audited"].(int)
 		numVulnerable := entry.Data["num_vulnerable"].(int)
+		excludedCount := entry.Data["num_exclusions"].(int)
 		buildVersion := entry.Data["version"].(string)
 
-		var summaryHeader = []string{"Audited Count", "Vulnerable Count", "Build Version"}
+		var summaryHeader = []string{"Audited Count", "Vulnerable Count", "Ignored Vulnerabilities", "Build Version"}
 		var invalidHeader = []string{"Count", "Package", "Reason"}
 		var auditedHeader = []string{"Count", "Package", "Is Vulnerable", "Num Vulnerabilities", "Vulnerabilities"}
-		var summaryRow = []string{strconv.Itoa(packageCount), strconv.Itoa(numVulnerable), buildVersion}
+		var summaryRow = []string{strconv.Itoa(packageCount), strconv.Itoa(numVulnerable), strconv.Itoa(excludedCount), buildVersion}
 
 		var buf bytes.Buffer
 		w := csv.NewWriter(&buf)

--- a/internal/audit/csvformatter_test.go
+++ b/internal/audit/csvformatter_test.go
@@ -36,6 +36,7 @@ func TestCsvOutputWhenQuiet(t *testing.T) {
 		},
 		"num_audited":    2,
 		"num_vulnerable": 1,
+		"num_exclusions": 0,
 		"version":        "development",
 	}
 	entry := Entry{Data: data}
@@ -44,8 +45,8 @@ func TestCsvOutputWhenQuiet(t *testing.T) {
 	logMessage, e := formatter.Format(&entry)
 	assert.Nil(t, e)
 	expectedCsv := `Summary
-Audited Count,Vulnerable Count,Build Version
-2,1,development
+Audited Count,Vulnerable Count,Ignored Vulnerabilities,Build Version
+2,1,0,development
 
 Audited Package(s)
 Count,Package,Is Vulnerable,Num Vulnerabilities,Vulnerabilities
@@ -65,6 +66,7 @@ func TestCsvOutput(t *testing.T) {
 		},
 		"num_audited":    2,
 		"num_vulnerable": 1,
+		"num_exclusions": 0,
 		"version":        "development",
 	}
 	entry := Entry{Data: data}
@@ -73,8 +75,8 @@ func TestCsvOutput(t *testing.T) {
 	logMessage, e := formatter.Format(&entry)
 	assert.Nil(t, e)
 	expectedCsv := `Summary
-Audited Count,Vulnerable Count,Build Version
-2,1,development
+Audited Count,Vulnerable Count,Ignored Vulnerabilities,Build Version
+2,1,0,development
 
 Invalid Package(s)
 Count,Package,Reason
@@ -115,9 +117,10 @@ func TestCsvFormatter_FormatNoError(t *testing.T) {
 		},
 		"num_audited":    0,
 		"num_vulnerable": 0,
+		"num_exclusions": 0,
 		"version":        "theBuildVersion",
 	}
 	buf, err := formatter.Format(&Entry{Data: data})
 	assert.NoError(t, err)
-	assert.Equal(t, "Summary\nAudited Count,Vulnerable Count,Build Version\n0,0,theBuildVersion\n", string(buf))
+	assert.Equal(t, "Summary\nAudited Count,Vulnerable Count,Ignored Vulnerabilities,Build Version\n0,0,0,theBuildVersion\n", string(buf))
 }


### PR DESCRIPTION
This pull request makes the following changes:
* Added an exclusion count to auditlog and auditlogtextformatter
* Now in summary table, there is a number of ignored deps highlighted in yellow, kinda like a warning

I'm unsure if y'all would rather it not be in the table though. I also think I could probably just list out the dependencies that are ignored but I am just now re-learning go so baby steps :)

I REALLY miss you all. <3

It relates to the following issue #s:
* Fixes  #232

cc @bhamail / @DarthHater
