### PR TITLE
Respect go mod replace directive

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -67,10 +67,12 @@ func GoListAgnostic(stdIn io.Reader) (deps types.ProjectList, err error) {
 
 		if module, ok := mod["Module"].(map[string]interface{}); ok {
 			// Ok, we are in Module town, so `go list -json -deps` has been run
-			// Respect the replace version if it exists
 			if replace, ok := module["Replace"].(map[string]interface{}); ok {
-				deps.Projects = append(deps.Projects, types.Projects{Version: replace["Version"].(string), Name: module["Path"].(string)})
-				continue
+				// A replace block has been found, let's try and do something with it
+				if version, ok := replace["Version"].(string); ok {
+					deps.Projects = append(deps.Projects, types.Projects{Version: version, Name: module["Path"].(string)})
+					continue
+				}
 			}
 			if version, ok := module["Version"].(string); ok {
 				// Intentionally skip checking if `Path` exists as a key, as it should if `Version` is there

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -67,6 +67,11 @@ func GoListAgnostic(stdIn io.Reader) (deps types.ProjectList, err error) {
 
 		if module, ok := mod["Module"].(map[string]interface{}); ok {
 			// Ok, we are in Module town, so `go list -json -deps` has been run
+			// Respect the replace version if it exists
+			if replace, ok := module["Replace"].(map[string]interface{}); ok {
+				deps.Projects = append(deps.Projects, types.Projects{Version: replace["Version"].(string), Name: module["Path"].(string)})
+				continue
+			}
 			if version, ok := module["Version"].(string); ok {
 				// Intentionally skip checking if `Path` exists as a key, as it should if `Version` is there
 				deps.Projects = append(deps.Projects, types.Projects{Version: version, Name: module["Path"].(string)})

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -56,6 +56,24 @@ func TestGoListDepsJson(t *testing.T) {
 	}
 }
 
+func TestGoListDepsJsonReplace(t *testing.T) {
+	goListFile, err := os.Open("testdata/golistdependenciesjsonreplace.out")
+	if err != nil {
+		t.Error(err)
+	}
+
+	deps, err := GoListAgnostic(goListFile)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(deps.Projects) != 1 {
+		t.Errorf("Unsuccessfully parsed go list -deps -json ./... output, 112 dependencies were expected, but %d encountered", len(deps.Projects))
+	}
+	if deps.Projects[0].Version != "v1.0.1-vault-3" {
+		t.Errorf("Unsuccessfully parsed go list -deps -json ./... output, 112 dependencies were expected, but %d encountered", len(deps.Projects))
+	}
+}
+
 func TestGoListAgnostic(t *testing.T) {
 	goListFile, err := os.Open("testdata/golist.out")
 	if err != nil {

--- a/parse/testdata/golistdependenciesjsonreplace.out
+++ b/parse/testdata/golistdependenciesjsonreplace.out
@@ -1,0 +1,51 @@
+{
+	"Dir": "/Users/bhamail/go/pkg/mod/github.com/hashicorp/hcl@v1.0.1-vault-3/hcl/strconv",
+	"ImportPath": "github.com/hashicorp/hcl/hcl/strconv",
+	"Name": "strconv",
+	"Root": "/Users/bhamail/go/pkg/mod/github.com/hashicorp/hcl@v1.0.1-vault-3",
+	"Module": {
+		"Path": "github.com/hashicorp/hcl",
+		"Version": "v1.0.0",
+		"Replace": {
+			"Path": "github.com/hashicorp/hcl",
+			"Version": "v1.0.1-vault-3",
+			"Time": "2021-06-11T21:31:12Z",
+			"Dir": "/Users/bhamail/go/pkg/mod/github.com/hashicorp/hcl@v1.0.1-vault-3",
+			"GoMod": "/Users/bhamail/go/pkg/mod/cache/download/github.com/hashicorp/hcl/@v/v1.0.1-vault-3.mod",
+			"GoVersion": "1.15"
+		},
+		"Indirect": true,
+		"Dir": "/Users/bhamail/go/pkg/mod/github.com/hashicorp/hcl@v1.0.1-vault-3",
+		"GoMod": "/Users/bhamail/go/pkg/mod/cache/download/github.com/hashicorp/hcl/@v/v1.0.1-vault-3.mod",
+		"GoVersion": "1.15"
+	},
+	"DepOnly": true,
+	"Stale": true,
+	"StaleReason": "not installed but available in build cache",
+	"GoFiles": [
+		"quote.go"
+	],
+	"Imports": [
+		"errors",
+		"unicode/utf8"
+	],
+	"Deps": [
+		"errors",
+		"internal/bytealg",
+		"internal/cpu",
+		"internal/reflectlite",
+		"internal/unsafeheader",
+		"runtime",
+		"runtime/internal/atomic",
+		"runtime/internal/math",
+		"runtime/internal/sys",
+		"unicode/utf8",
+		"unsafe"
+	],
+	"TestGoFiles": [
+		"quote_test.go"
+	],
+	"TestImports": [
+		"testing"
+	]
+}


### PR DESCRIPTION
Respect the go mod replace directive for `go list -deps -json`

This pull request makes the following changes:
* Respects go mod replace directive for `go list -deps -json`

It relates to the following issue #s:
* Fixes #254

cc @bhamail / @DarthHater
