### PR TITLE
Use build info when available (go install)

### DIFF
--- a/buildversion/version.go
+++ b/buildversion/version.go
@@ -16,9 +16,16 @@
 
 package buildversion
 
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+const DefaultVersion = "0.0.0-dev"
+
 var (
 	// these are overwritten/populated via build CLI
-	BuildVersion = "0.0.0-dev"
+	BuildVersion = DefaultVersion
 	BuildTime    = ""
 	BuildCommit  = ""
 )
@@ -30,4 +37,16 @@ var packageManager = "source"
 
 func PackageManager() string {
 	return packageManager
+}
+
+func init() {
+	// Use build info from debug package if available, and if no build info is
+	// provided via build CLI.
+	info, available := debug.ReadBuildInfo()
+	if available && info.Main.Version != "" && BuildTime == "" && BuildCommit == "" && BuildVersion == DefaultVersion {
+		BuildVersion = info.Main.Version
+		BuildCommit = fmt.Sprintf("(unknown, mod sum: %q)", info.Main.Sum)
+		BuildTime = "(unknown)"
+	}
+
 }

--- a/buildversion/version.go
+++ b/buildversion/version.go
@@ -43,7 +43,8 @@ func init() {
 	// Use build info from debug package if available, and if no build info is
 	// provided via build CLI.
 	info, available := debug.ReadBuildInfo()
-	if available && info.Main.Version != "" && BuildTime == "" && BuildCommit == "" && BuildVersion == DefaultVersion {
+	// info.Main.Version will be "" when debugging, and "(devel)" when building with no arguments
+	if available && info.Main.Version != "" && info.Main.Version != "(devel)" && BuildTime == "" && BuildCommit == "" && BuildVersion == DefaultVersion {
 		BuildVersion = info.Main.Version
 		BuildCommit = fmt.Sprintf("(unknown, mod sum: %q)", info.Main.Sum)
 		BuildTime = "(unknown)"


### PR DESCRIPTION
Currently, installing nancy via `go install` results in `nancy --version` returning `0.0.0-dev` instead of the version that was actually installed. The solution is to add an init function that uses `debug.ReadBuildInfo()` from the `runtime/debug` package in order to get the actual version (if one is available). This is loosely based on the behavior of tools such as https://github.com/golangci/golangci-lint/blob/master/cmd/golangci-lint/mod_version.go#L9

This pull request makes the following changes:
* Adds an `init()` function on the `buildversion` package that attempts to retrieve the version information from `debug.ReadBuildInfo()` (if available, and if the build information is not overridden via the build CLI)

cc @bhamail / @DarthHater
