### PR TITLE
Normalize version when using go install

### DIFF
--- a/buildversion/version.go
+++ b/buildversion/version.go
@@ -19,6 +19,8 @@ package buildversion
 import (
 	"fmt"
 	"runtime/debug"
+
+	"github.com/blang/semver"
 )
 
 const DefaultVersion = "0.0.0-dev"
@@ -39,13 +41,30 @@ func PackageManager() string {
 	return packageManager
 }
 
+func NormalizeVersion(version string) (string, error) {
+	if version[0] == 'v' {
+		// Normalize version tags in the form v1.1.1 to 1.1.1
+		version = version[1:]
+	}
+	// Ensure that version tag can be parsed correctly
+	_, err := semver.Parse(version)
+	if err != nil {
+		return version, err
+	}
+	return version, nil
+}
+
 func init() {
 	// Use build info from debug package if available, and if no build info is
 	// provided via build CLI.
 	info, available := debug.ReadBuildInfo()
 	// info.Main.Version will be "" when debugging, and "(devel)" when building with no arguments
 	if available && info.Main.Version != "" && info.Main.Version != "(devel)" && BuildTime == "" && BuildCommit == "" && BuildVersion == DefaultVersion {
-		BuildVersion = info.Main.Version
+		version, err := NormalizeVersion(info.Main.Version)
+		if err != nil {
+			return
+		}
+		BuildVersion = version
 		BuildCommit = fmt.Sprintf("(unknown, mod sum: %q)", info.Main.Sum)
 		BuildTime = "(unknown)"
 	}

--- a/buildversion/version_test.go
+++ b/buildversion/version_test.go
@@ -33,3 +33,45 @@ func TestDefaultBuildTime(t *testing.T) {
 func TestDefaultBuildCommit(t *testing.T) {
 	assert.Equal(t, "", BuildCommit)
 }
+
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		expected   string
+		input      string
+		shouldFail bool
+	}{
+		{
+			input:    "1.1.1",
+			expected: "1.1.1",
+		},
+		{
+			input:    "v1.1.1",
+			expected: "1.1.1",
+		},
+		{
+			input:      "x1.1.1",
+			shouldFail: true,
+		},
+		{
+			input:      "vv1.1.1",
+			shouldFail: true,
+		},
+		{
+			input:      "1.1",
+			shouldFail: true,
+		},
+		{
+			input:      "foobar",
+			shouldFail: true,
+		},
+	}
+	for _, test := range tests {
+		actual, err := NormalizeVersion(test.input)
+		if test.shouldFail {
+			assert.Error(t, err)
+			continue
+		}
+		assert.NoError(t, err)
+		assert.Equal(t, test.expected, actual)
+	}
+}


### PR DESCRIPTION

This pull request makes the following changes:
* fixes issue with unnormalized version tags when installing via `go install` (e.g., v1.1.1 vs 1.1.1)

It relates to the following issue #s:
* Fixes issues introduced in https://github.com/sonatype-nexus-community/nancy/pull/265

cc @bhamail / @DarthHater
