### PR TITLE
fix #264: restore v version prefix

### DIFF
--- a/packages/dep.go
+++ b/packages/dep.go
@@ -17,8 +17,6 @@
 package packages
 
 import (
-	"strings"
-
 	"github.com/Masterminds/semver"
 	"github.com/golang/dep"
 )
@@ -28,11 +26,7 @@ func ExtractPurlsUsingDep(project *dep.Project) ([]string, []string) {
 	var purls []string
 	var invalidPurls []string
 	for _, lockedProject := range lockedProjects {
-		var version string
-		i := lockedProject.Version().String()
-
-		version = strings.Replace(i, "v", "", -1)
-
+		version := lockedProject.Version().String()
 		if len(version) > 0 { // There must be a version we can use
 			name := lockedProject.Ident().String()
 			packageName := convertGopkgNameToPurl(name)

--- a/packages/dep_int_test.go
+++ b/packages/dep_int_test.go
@@ -56,13 +56,13 @@ func TestExtractPurlsFromManifestUsingDep(t *testing.T) {
 	assertPurlFound("pkg:golang/golang.org/x/sync@master", invalidPurls, t)
 	assertPurlFound("pkg:golang/golang.org/x/sys@master", invalidPurls, t)
 
-	assertPurlFound("pkg:golang/github.com/go-yaml/yaml@2", purls, t)
-	assertPurlFound("pkg:golang/github.com/Masterminds/vcs@1.11.1", purls, t)
-	assertPurlFound("pkg:golang/github.com/boltdb/bolt@1.3.1", purls, t)
-	assertPurlFound("pkg:golang/github.com/golang/protobuf@1.0.0", purls, t)
-	assertPurlFound("pkg:golang/github.com/jmank88/nuts@0.3.0", purls, t)
-	assertPurlFound("pkg:golang/github.com/pelletier/go-toml@1.2.0", purls, t)
-	assertPurlFound("pkg:golang/github.com/pkg/errors@0.8.0", purls, t)
+	assertPurlFound("pkg:golang/github.com/go-yaml/yaml@v2", purls, t)
+	assertPurlFound("pkg:golang/github.com/Masterminds/vcs@v1.11.1", purls, t)
+	assertPurlFound("pkg:golang/github.com/boltdb/bolt@v1.3.1", purls, t)
+	assertPurlFound("pkg:golang/github.com/golang/protobuf@v1.0.0", purls, t)
+	assertPurlFound("pkg:golang/github.com/jmank88/nuts@v0.3.0", purls, t)
+	assertPurlFound("pkg:golang/github.com/pelletier/go-toml@v1.2.0", purls, t)
+	assertPurlFound("pkg:golang/github.com/pkg/errors@v0.8.0", purls, t)
 }
 
 func assertPurlFound(expectedPurl string, result []string, t *testing.T) {

--- a/packages/mod.go
+++ b/packages/mod.go
@@ -30,10 +30,8 @@ type Mod struct {
 func (m Mod) ExtractPurlsFromManifest() (purls []string) {
 	for _, s := range m.ProjectList.Projects {
 		if len(s.Version) > 0 { // There must be a version we can use
-			// OSS Index no likey v before version, IQ does though, comment left so I will never forget.
-			// go-sona-types library now takes care of querying both ossi and iq with reformatted purls as needed (to v or not to v).
-			version := strings.Replace(s.Version, "v", "", -1)
-			version = strings.Replace(version, "+incompatible", "", -1)
+			// remove "+incompatible" from version string if it exists
+			version := strings.Replace(s.Version, "+incompatible", "", -1)
 			var purl = "pkg:" + convertGopkgNameToPurl(s.Name) + "@" + version
 			purls = append(purls, purl)
 		}


### PR DESCRIPTION
OSS Index used to require the version for golang components to not have a "v" prefix. This has changed, so now both OSS Index and IQ are happy with golang components who's version string is prefixed with a "v".

This PR removes the code that removed the "v".

* Fixes #264

cc @bhamail / @DarthHater
