### PR TITLE
Refactor tests to T.TempDir instead of os.MkdirTemp

### DIFF
--- a/internal/cmd/iq_test.go
+++ b/internal/cmd/iq_test.go
@@ -92,8 +92,7 @@ func TestInitIQConfig(t *testing.T) {
 	viper.Reset()
 	defer viper.Reset()
 
-	tempDir := setupConfig(t)
-	defer resetConfig(t, tempDir)
+	tempDir := t.TempDir()
 
 	setupTestOSSIConfigFileValues(t, tempDir)
 	defer func() {
@@ -128,8 +127,7 @@ func TestInitIQConfigWithNoConfigFile(t *testing.T) {
 	viper.Reset()
 	defer viper.Reset()
 
-	tempDir := setupConfig(t)
-	defer resetConfig(t, tempDir)
+	tempDir := t.TempDir()
 
 	setupTestOSSIConfigFileValues(t, tempDir)
 	defer func() {
@@ -360,8 +358,7 @@ func TestIqCreatorDefaultOptions(t *testing.T) {
 	viper.Reset()
 	defer viper.Reset()
 
-	tempDir := setupConfig(t)
-	defer resetConfig(t, tempDir)
+	tempDir := t.TempDir()
 
 	// setup empty config files
 	setupTestOSSIConfigFile(t, tempDir)

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -320,24 +320,11 @@ func TestConfigOssi_skip_update_check(t *testing.T) {
 	validateConfigOssi(t, types.Configuration{SkipUpdateCheck: true}, []string{"--skip-update-check"}...)
 }
 
-func setupConfig(t *testing.T) (tempDir string) {
-	tempDir, err := os.MkdirTemp("", "config-test")
-	assert.NoError(t, err)
-	return tempDir
-}
-
-func resetConfig(t *testing.T, tempDir string) {
-	var err error
-	assert.NoError(t, err)
-	_ = os.RemoveAll(tempDir)
-}
-
 func TestInitConfig(t *testing.T) {
 	viper.Reset()
 	defer viper.Reset()
 
-	tempDir := setupConfig(t)
-	defer resetConfig(t, tempDir)
+	tempDir := t.TempDir()
 
 	setupTestOSSIConfigFileValues(t, tempDir)
 	defer func() {
@@ -354,8 +341,7 @@ func TestInitConfigWithNoConfigFile(t *testing.T) {
 	viper.Reset()
 	defer viper.Reset()
 
-	tempDir := setupConfig(t)
-	defer resetConfig(t, tempDir)
+	tempDir := t.TempDir()
 
 	setupTestOSSIConfigFileValues(t, tempDir)
 	defer func() {

--- a/internal/cmd/sleuth_test.go
+++ b/internal/cmd/sleuth_test.go
@@ -101,7 +101,7 @@ func TestConfigOssi_exclude_vulnerabilities_file_not_found_does_not_matter(t *te
 }
 
 func TestConfigOssi_exclude_vulnerabilities_passed_as_directory_does_not_matter(t *testing.T) {
-	dir, _ := os.MkdirTemp("", "prefix")
+	dir := t.TempDir()
 	validateConfigOssi(t, types.Configuration{CveList: types.CveListFlag{}, Formatter: defaultAuditLogFormatter},
 		[]string{sleuthCmd.Use, "--exclude-vulnerability-file=" + dir}...)
 }


### PR DESCRIPTION
Replace `os.MkdirTemp` with `T.TempDir` in order to simplify tests. [`T.TempDir`](https://pkg.go.dev/testing#T.TempDir) creates and automatically deletes a temporary directory after the finished test.

This pull request makes the following changes:
* replace `setupConfig(t)`, `os.MkdirTemp(...)`  with `t.TempDir()`;
* remove usages and functions itself: `setupConfig` (which creates temp directory by calling `os.MkdirTemp`)) and `resetConfig` (which removes temp directory created by `setupConfig`).

cc @bhamail / @DarthHater
