### PR TITLE
fix: cap stdin read at 10 MB to prevent memory exhaustion (closes #291)

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -19,6 +19,7 @@ package parse
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 
@@ -45,8 +46,16 @@ func GoList(stdIn *bufio.Scanner) (deps types.ProjectList, err error) {
 func GoListAgnostic(stdIn io.Reader) (deps types.ProjectList, err error) {
 	// stdIn should never be massive, so taking this approach over reading from a stream
 	// multiple times
-	johnnyFiveNeedInput, err := io.ReadAll(stdIn)
+	const maxStdinBytes = 10 * 1024 * 1024 // 10 MB
+
+	limited := io.LimitReader(stdIn, maxStdinBytes+1)
+	johnnyFiveNeedInput, err := io.ReadAll(limited)
 	if err != nil {
+		return
+	}
+	if int64(len(johnnyFiveNeedInput)) > maxStdinBytes {
+		err = fmt.Errorf("stdin input exceeded %d MB limit; ensure you are piping valid 'go list' output",
+			maxStdinBytes/(1024*1024))
 		return
 	}
 	decoder := json.NewDecoder(strings.NewReader(string(johnnyFiveNeedInput)))

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -18,6 +18,7 @@ package parse
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"os"
 	"strings"
@@ -223,6 +224,18 @@ golang.org/x/sys v0.0.0-20181228144115-9a3f9b0469bb`
 
 	if len(deps.Projects) != 16 {
 		t.Error(deps)
+	}
+}
+
+func TestGoListAgnosticRejectsOversizedInput(t *testing.T) {
+	// Generate input slightly over 10 MB
+	oversized := bytes.Repeat([]byte("x"), 10*1024*1024+1)
+	_, err := GoListAgnostic(bytes.NewReader(oversized))
+	if err == nil {
+		t.Error("Expected an error for oversized stdin input, but got nil")
+	}
+	if err != nil && !strings.Contains(err.Error(), "exceeded") {
+		t.Errorf("Expected error message to contain 'exceeded', but got: %s", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Wraps the `io.ReadAll` call in `parse/parse.go` with `io.LimitReader` to cap stdin at 10 MB
- Input exceeding the limit returns a clear error message instead of exhausting memory
- Includes a regression test (`TestGoListAgnosticRejectsOversizedInput`) for the oversized input case

## Test plan

- [ ] `go test ./parse/...` passes (all existing tests green, new test green)
- [ ] `go build ./...` compiles cleanly
- [ ] Manual: pipe a file larger than 10 MB and confirm the error message contains "exceeded"

Closes #291

Generated with [Claude Code](https://claude.com/claude-code)