### PR TITLE
feat: set maximum go list input size via CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - [Sonatype Guide Options](#sonatype-guide-options)
   - [Using a custom server URL](#using-a-custom-server-url)
   - [Loud mode](#loud-mode)
+  - [Maximum input size](#maximum-input-size)
   - [Exclude vulnerabilities](#exclude-vulnerabilities)
   - [Output](#output)
 - [Sonatype Lifecycle Options](#sonatype-lifecycle-options)
@@ -171,16 +172,17 @@ Available Commands:
   update      Check if there are any updates available
 
 Flags:
-  -v, -- count                 Set log level, multiple v's is more verbose
-  -c, --clean-cache            Deletes local cache directory
-  -d, --db-cache-path string   Specify an alternate path for caching responses from Sonatype Guide, example: /tmp
-  -h, --help                   help for nancy
-      --loud                   indicate output should include non-vulnerable packages
-  -q, --quiet                  indicate output should contain only packages with vulnerabilities (default true)
-      --skip-update-check      Skip the check for updates.
-  -t, --token string           Specify OSS Index API token for request (deprecated, use --guide-token)
-  -u, --username string        Specify OSS Index username for request (deprecated, use --guide-token)
-  -V, --version                Get the version
+  -v, -- count                        Set log level, multiple v's is more verbose
+  -c, --clean-cache                   Deletes local cache directory
+  -d, --db-cache-path string          Specify an alternate path for caching responses from Sonatype Guide, example: /tmp
+  -h, --help                          help for nancy
+      --loud                          indicate output should include non-vulnerable packages
+      --max-go-list-input-size int    Maximum size, in MB, of 'go list' output to read from stdin (default 100)
+  -q, --quiet                         indicate output should contain only packages with vulnerabilities (default true)
+      --skip-update-check             Skip the check for updates.
+  -t, --token string                  Specify OSS Index API token for request (deprecated, use --guide-token)
+  -u, --username string               Specify OSS Index username for request (deprecated, use --guide-token)
+  -V, --version                       Get the version
 
 Use "nancy [command] --help" for more information about a command.
 
@@ -205,14 +207,15 @@ Flags:
   -o, --output string                                    Styling for output format. json, json-pretty, text, csv (default "text")
 
 Global Flags:
-  -v, -- count                 Set log level, multiple v's is more verbose
-  -d, --db-cache-path string   Specify an alternate path for caching responses from Sonatype Guide, example: /tmp
-      --loud                   indicate output should include non-vulnerable packages
-  -q, --quiet                  indicate output should contain only packages with vulnerabilities (default true)
-      --skip-update-check      Skip the check for updates.
-  -t, --token string           Specify OSS Index API token for request (deprecated, use --guide-token)
-  -u, --username string        Specify OSS Index username for request (deprecated, use --guide-token)
-  -V, --version                Get the version
+  -v, -- count                        Set log level, multiple v's is more verbose
+  -d, --db-cache-path string          Specify an alternate path for caching responses from Sonatype Guide, example: /tmp
+      --loud                          indicate output should include non-vulnerable packages
+      --max-go-list-input-size int    Maximum size, in MB, of 'go list' output to read from stdin (default 100)
+  -q, --quiet                         indicate output should contain only packages with vulnerabilities (default true)
+      --skip-update-check             Skip the check for updates.
+  -t, --token string                  Specify OSS Index API token for request (deprecated, use --guide-token)
+  -u, --username string               Specify OSS Index username for request (deprecated, use --guide-token)
+  -V, --version                       Get the version
 
 $ > nancy lifecycle --help
 'nancy lifecycle' is a command to check for vulnerabilities in your Golang dependencies using Sonatype Lifecycle.
@@ -234,14 +237,15 @@ Flags:
   -l, --lifecycle-username string         Specify Sonatype Lifecycle username for request (default "admin")
 
 Global Flags:
-  -v, -- count                 Set log level, multiple v's is more verbose
-  -d, --db-cache-path string   Specify an alternate path for caching responses from Sonatype Guide, example: /tmp
-      --loud                   indicate output should include non-vulnerable packages
-  -q, --quiet                  indicate output should contain only packages with vulnerabilities (default true)
-      --skip-update-check      Skip the check for updates.
-  -t, --token string           Specify OSS Index API token for request (deprecated, use --guide-token)
-  -u, --username string        Specify OSS Index username for request (deprecated, use --guide-token)
-  -V, --version                Get the version
+  -v, -- count                        Set log level, multiple v's is more verbose
+  -d, --db-cache-path string          Specify an alternate path for caching responses from Sonatype Guide, example: /tmp
+      --loud                          indicate output should include non-vulnerable packages
+      --max-go-list-input-size int    Maximum size, in MB, of 'go list' output to read from stdin (default 100)
+  -q, --quiet                         indicate output should contain only packages with vulnerabilities (default true)
+      --skip-update-check             Skip the check for updates.
+  -t, --token string                  Specify OSS Index API token for request (deprecated, use --guide-token)
+  -u, --username string               Specify OSS Index username for request (deprecated, use --guide-token)
+  -V, --version                       Get the version
 ```
 
 > **Gopkg.lock support removed in v2.0.0**
@@ -389,6 +393,14 @@ By default, `nancy` runs in a "quiet" mode, only displaying a list of vulnerable
 You can run `nancy` in a loud manner, showing all components by running:
 
 - `go list -json -deps ./... | nancy sleuth --loud`
+
+### Maximum input size
+
+By default, `nancy` accepts up to 100 MB of `go list` output from stdin. This limit can be raised (or lowered) with `--max-go-list-input-size`, specified in megabytes:
+
+```shell
+go list -json -deps ./... | nancy sleuth --max-go-list-input-size 250
+```
 
 ### Exclude vulnerabilities
 

--- a/internal/cmd/lifecycle.go
+++ b/internal/cmd/lifecycle.go
@@ -175,7 +175,7 @@ func getPurls() (purls []string, err error) {
 	}
 
 	mod := packages.Mod{}
-	mod.ProjectList, err = parse.GoListAgnostic(reader)
+	mod.ProjectList, err = parse.GoListAgnostic(reader, maxStdInBytes())
 	if err != nil {
 		logLady.WithError(err).Error(unexpectedLifecycleErr)
 		panic(err)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -184,7 +184,7 @@ const (
 	flagNameOssiToken          = "token"
 	flagNameOssiURL            = "ossindex-url"
 	flagNameGuideToken         = "guide-token"
-	flagNameMaxGoListInputSize = "max-input-size"
+	flagNameMaxGoListInputSize = "max-go-list-input-size"
 
 	viperKeyOSSIndexURL  = "ossi.OSSIndexURL"
 	viperKeyOssiUsername = "ossi.Username"

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -100,13 +100,14 @@ var (
 	excludeVulnerabilityFilePath            string
 	additionalExcludeVulnerabilityFilePaths []string
 	outputFormat                            string
+	maxInputSizeMB                          int64
 	logLady                                 *logrus.Logger
 	ossiCreator                             serverCreator = ossiFactory{}
-	unixComments                                              = regexp.MustCompile(`#.*$`)
-	untilComment                                              = regexp.MustCompile(`(until=)(.*)`)
+	unixComments                                          = regexp.MustCompile(`#.*$`)
+	untilComment                                          = regexp.MustCompile(`(until=)(.*)`)
 )
 
-//Substitute the _ to .
+// Substitute the _ to .
 var viperKeyReplacer = strings.NewReplacer(".", "_")
 
 func setupViperAutomaticEnv() {
@@ -179,10 +180,11 @@ func Execute() (err error) {
 
 const defaultExcludeFilePath = "./.nancy-ignore"
 const (
-	flagNameOssiUsername = "username"
-	flagNameOssiToken    = "token"
-	flagNameOssiURL      = "ossindex-url"
-	flagNameGuideToken   = "guide-token"
+	flagNameOssiUsername       = "username"
+	flagNameOssiToken          = "token"
+	flagNameOssiURL            = "ossindex-url"
+	flagNameGuideToken         = "guide-token"
+	flagNameMaxGoListInputSize = "max-input-size"
 
 	viperKeyOSSIndexURL  = "ossi.OSSIndexURL"
 	viperKeyOssiUsername = "ossi.Username"
@@ -203,8 +205,20 @@ func init() {
 	persistentFlags.StringVarP(&configOssi.Username, flagNameOssiUsername, "u", "", "Specify OSS Index username for request (Deprecated: use --guide-token)")
 	persistentFlags.StringVarP(&configOssi.Token, flagNameOssiToken, "t", "", "Specify OSS Index API token for request (Deprecated: use --guide-token)")
 	persistentFlags.StringVar(&configOssi.OSSIndexURL, flagNameOssiURL, "", "Specify an alternate OSS Index URL/host")
-persistentFlags.StringVarP(&configOssi.DBCachePath, "db-cache-path", "d", "", "Specify an alternate path for caching responses from OSS Inde, example: /tmp")
+	persistentFlags.StringVarP(&configOssi.DBCachePath, "db-cache-path", "d", "", "Specify an alternate path for caching responses from OSS Index, example: /tmp")
 	persistentFlags.BoolVar(&configOssi.SkipUpdateCheck, "skip-update-check", false, "Skip the check for updates.")
+	persistentFlags.Int64Var(&maxInputSizeMB, flagNameMaxGoListInputSize, parse.DefaultMaxStdInBytes/(1024*1024),
+		"Maximum size, in MB, of 'go list' output to read from stdin")
+}
+
+// maxStdInBytes converts the configured --max-input-size flag (in MB) to bytes
+// for use when parsing 'go list' output. If the configured value is <= 0, it
+// falls back to the default so the parse layer never receives an invalid cap.
+func maxStdInBytes() int64 {
+	if maxInputSizeMB <= 0 {
+		return parse.DefaultMaxStdInBytes
+	}
+	return maxInputSizeMB * 1024 * 1024
 }
 
 func bindViperRootCmd() {
@@ -442,7 +456,7 @@ func doStdInAndParse(ossIndex localossindex.IServer) (err error) {
 
 	mod := packages.Mod{}
 
-	mod.ProjectList, err = parse.GoListAgnostic(reader)
+	mod.ProjectList, err = parse.GoListAgnostic(reader, maxStdInBytes())
 	if err != nil {
 		logLady.Error(err)
 		return
@@ -487,4 +501,3 @@ func convertInvalidPurlsToCoordinates(invalidPurls []string) []localossindex.Coo
 	}
 	return invalidCoordinates
 }
-

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -38,15 +38,22 @@ func GoList(stdIn *bufio.Scanner) (deps types.ProjectList, err error) {
 	return deps, nil
 }
 
+// DefaultMaxStdInBytes is the default cap on the amount of 'go list' output
+// read from stdin when no explicit limit is provided.
+const DefaultMaxStdInBytes int64 = 100 * 1024 * 1024 // 100 MB
+
 // GoListAgnostic will take an io.Reader that is likely the os.StdIn, and parse it as
 // a map of string keys to interfaces. If a "Module" key exists, I know I'm in
 // 'go list -json -deps' town. If it doesn't, I look for a "Path" key, which is 'go list -json -m all' town.
 // If I find nothing, then I try and parse it like I'm parsing a non json output
 // It returns either an error, or a deps of types.ProjectList
-func GoListAgnostic(stdIn io.Reader) (deps types.ProjectList, err error) {
+func GoListAgnostic(stdIn io.Reader, maxStdinBytes int64) (deps types.ProjectList, err error) {
+	if maxStdinBytes <= 0 {
+		maxStdinBytes = DefaultMaxStdInBytes
+	}
+
 	// stdIn should never be massive, so taking this approach over reading from a stream
 	// multiple times
-	const maxStdinBytes = 10 * 1024 * 1024 // 10 MB
 
 	limited := io.LimitReader(stdIn, maxStdinBytes+1)
 	johnnyFiveNeedInput, err := io.ReadAll(limited)

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -33,7 +33,7 @@ func TestGoListJson(t *testing.T) {
 		t.Error(err)
 	}
 
-	deps, err := GoListAgnostic(goListJSONFile)
+	deps, err := GoListAgnostic(goListJSONFile, DefaultMaxStdInBytes)
 	if err != nil {
 		t.Error(err)
 	}
@@ -48,7 +48,7 @@ func TestGoListDepsJson(t *testing.T) {
 		t.Error(err)
 	}
 
-	deps, err := GoListAgnostic(goListFile)
+	deps, err := GoListAgnostic(goListFile, DefaultMaxStdInBytes)
 	if err != nil {
 		t.Error(err)
 	}
@@ -63,7 +63,7 @@ func TestGoListDepsJsonReplace(t *testing.T) {
 		t.Error(err)
 	}
 
-	deps, err := GoListAgnostic(goListFile)
+	deps, err := GoListAgnostic(goListFile, DefaultMaxStdInBytes)
 	if err != nil {
 		t.Error(err)
 	}
@@ -81,7 +81,7 @@ func TestGoListDepsJsonReplacePath(t *testing.T) {
 		t.Error(err)
 	}
 
-	deps, err := GoListAgnostic(goListFile)
+	deps, err := GoListAgnostic(goListFile, DefaultMaxStdInBytes)
 	if err != nil {
 		t.Error(err)
 	}
@@ -102,7 +102,7 @@ func TestGoListAgnostic(t *testing.T) {
 		t.Error(err)
 	}
 
-	deps, err := GoListAgnostic(goListFile)
+	deps, err := GoListAgnostic(goListFile, DefaultMaxStdInBytes)
 	if err != nil {
 		t.Error(err)
 	}
@@ -117,7 +117,7 @@ func TestGoListJsonReplace(t *testing.T) {
 		t.Error(err)
 	}
 
-	deps, err := GoListAgnostic(goListJSONReplaceFile)
+	deps, err := GoListAgnostic(goListJSONReplaceFile, DefaultMaxStdInBytes)
 	if err != nil {
 		t.Error(err)
 	}
@@ -136,7 +136,7 @@ func TestGoListJsonReplacePath(t *testing.T) {
 		t.Error(err)
 	}
 
-	deps, err := GoListAgnostic(goListJSONReplaceFile)
+	deps, err := GoListAgnostic(goListJSONReplaceFile, DefaultMaxStdInBytes)
 	if err != nil {
 		t.Error(err)
 	}
@@ -158,7 +158,7 @@ func TestGoListReplace(t *testing.T) {
 		t.Error(err)
 	}
 
-	deps, err := GoListAgnostic(goListReplaceFile)
+	deps, err := GoListAgnostic(goListReplaceFile, DefaultMaxStdInBytes)
 	if err != nil {
 		t.Error(err)
 	}
@@ -228,14 +228,40 @@ golang.org/x/sys v0.0.0-20181228144115-9a3f9b0469bb`
 }
 
 func TestGoListAgnosticRejectsOversizedInput(t *testing.T) {
-	// Generate input slightly over 10 MB
-	oversized := bytes.Repeat([]byte("x"), 10*1024*1024+1)
-	_, err := GoListAgnostic(bytes.NewReader(oversized))
+	// Generate input slightly over an explicit small cap to keep the test fast.
+	const maxBytes = 1024
+	oversized := bytes.Repeat([]byte("x"), maxBytes+1)
+	_, err := GoListAgnostic(bytes.NewReader(oversized), maxBytes)
 	if err == nil {
 		t.Error("Expected an error for oversized stdin input, but got nil")
 	}
 	if err != nil && !strings.Contains(err.Error(), "exceeded") {
 		t.Errorf("Expected error message to contain 'exceeded', but got: %s", err.Error())
+	}
+}
+
+func TestGoListAgnosticDefaultsToDefaultMaxWhenNonPositive(t *testing.T) {
+	// A value <= 0 should fall back to the default.
+	// Use 2 KB of input with a max of 0 — this proves the fallback accepts input under the default cap.
+	input := bytes.Repeat([]byte("x"), 2*1024)
+	_, err := GoListAgnostic(bytes.NewReader(input), 0)
+	if err != nil {
+		t.Errorf("Expected input under the default cap to be accepted, but got error: %s", err.Error())
+	}
+}
+
+func TestGoListAgnosticHonorsConfigurableLimit(t *testing.T) {
+	// 2 KB input exceeds a 1 KB cap but fits under a 4 KB cap.
+	input := bytes.Repeat([]byte("x"), 2*1024)
+
+	_, err := GoListAgnostic(bytes.NewReader(input), 1024)
+	if err == nil {
+		t.Error("Expected error when input exceeds configured limit, but got nil")
+	}
+
+	_, err = GoListAgnostic(bytes.NewReader(input), 4*1024)
+	if err != nil {
+		t.Errorf("Expected input under the configured cap to be accepted, but got error: %s", err.Error())
 	}
 }
 


### PR DESCRIPTION
https://github.com/sonatype-nexus-community/nancy/pull/298 introduced a hard-coded cap on the input size `nancy` would accept from `go list`. This breaks CI larger projects where the output size exceeds the limit.

This pull request makes the following changes:
* increases the default limit to 100MB
* makes the cap configurable using a new command like flag `max-go-list-input-size`

This changes the `GoListAgnostic` function signature, which might be considered breaking. If the maintainers would prefer, I'm open to changing the function to accept a config object that leaves it open to future options without touching the signature again, but it seemed like overkill at this point.

It relates to the following issue #s:
* Fixes https://github.com/sonatype-nexus-community/nancy/issues/305

cc @sonatype-nexus-community/nancy
